### PR TITLE
use Semaphore for CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,7 +11,7 @@ blocks:
         - name: flake8
           commands:
             - sem-version python 3.8
-            - checkout
+            - checkout --use-cache
             - python -m pip install --upgrade poetry
             - poetry install
-            - poetry run flake8 || true
+            - git diff origin/master | poetry run flake8 --diff

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,13 +5,13 @@ agent:
     type: e1-standard-2
     os_image: ubuntu1804
 blocks:
-  - name: Test
+  - name: Lint
     task:
       jobs:
-        - name: Database
+        - name: flake8
           commands:
             - sem-version python 3.8
             - checkout
             - python -m pip install --upgrade poetry
             - poetry install
-            - poetry run black --check .
+            - git diff origin/master | poetry run flake8 --diff

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,4 +14,4 @@ blocks:
             - checkout
             - python -m pip install --upgrade poetry
             - poetry install
-            - git diff origin/master | poetry run flake8 --diff
+            - poetry run flake8 || true

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,17 @@
+version: v1.0
+name: Python
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Test
+    task:
+      jobs:
+        - name: Database
+          commands:
+            - sem-version python 3.8
+            - checkout
+            - python -m pip install --upgrade poetry
+            - poetry install
+            - poetry run python3 -m unittest src/replit/test_database.py

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,4 +14,4 @@ blocks:
             - checkout
             - python -m pip install --upgrade poetry
             - poetry install
-            - poetry run python3 -m unittest src/replit/test_database.py
+            - poetry run black --check .

--- a/src/replit/database/__init__.py
+++ b/src/replit/database/__init__.py
@@ -10,8 +10,7 @@ import aiohttp
 import nest_asyncio
 
 
-JSON_TYPE = Union[str,
-int, float, bool, type(None), dict, list]
+JSON_TYPE = Union[str, int, float, bool, type(None), dict, list]
 
 
 class AsyncJSONKey:

--- a/src/replit/database/__init__.py
+++ b/src/replit/database/__init__.py
@@ -10,7 +10,8 @@ import aiohttp
 import nest_asyncio
 
 
-JSON_TYPE = Union[str, int, float, bool, type(None), dict, list]
+JSON_TYPE = Union[str,
+int, float, bool, type(None), dict, list]
 
 
 class AsyncJSONKey:


### PR DESCRIPTION
This is useful for making sure that PRs pass the linter successfully. I also want to run tests for the Database client in the future.

The only thing Semaphore will do with this change is run flake8 against any files changed from master.