### PR TITLE
Add CLI for Repl DB interactions

### DIFF
--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -1,45 +1,39 @@
+"""CLI for interacting with your Repl's DB. Written as top-level script."""
 import json
 
 import click
 
 from replit import db as database
-import replit.termutils as term
+from replit import termutils as term
 
 
-def wrap(color: term.Color, value: str):
-    return color.fg + value + term.reset
-
-
-def info(value: str):
+def info(value: str) -> str:
+    """Wrap given string in a blue color for info contexts."""
     return term.brightblue.fg + value + term.reset
 
 
-def success(value: str):
+def success(value: str) -> str:
+    """Wrap given string in a green color for success contexts."""
     return term.brightgreen.fg + value + term.reset
 
 
-def failure(value: str):
+def failure(value: str) -> str:
+    """Wrap given string in a red color for failure/warning contexts."""
     return term.brightred.fg + value + term.reset
-
-
-def chunk(lst: list, n: int):
-    for i in range(0, len(lst), n):
-        yield lst[i:i + n]
 
 
 @click.group()
 @click.version_option("0.0.1")
-def cli():
+def cli() -> None:
     """CLI for interacting with your Repl's DB."""
 
 
 @cli.command(name="keys")
 @click.argument("file_path", default="db_keys.json")
-def list_keys(file_path: str):
-    """Writes all keys in the DB to a JSON file."""
-
+def list_keys(file_path: str) -> None:
+    """Save all keys in the DB to a JSON file."""
     try:
-        file = open(file_path, 'w+')
+        file = open(file_path, "w+")
     except FileNotFoundError:
         click.echo(failure(f"No such file or directory '{file_path}'"))
     else:
@@ -51,14 +45,13 @@ def list_keys(file_path: str):
 
 @cli.command(name="match")
 @click.argument("prefix")
-def find_matches(prefix: str):
-    """Finds keys with a given prefix."""
-
+def find_matches(prefix: str) -> None:
+    """List all keys that match the given prefix."""
     matches = list(database.prefix(prefix))
 
     if matches:
         click.echo(success(f"Matches found for '{prefix}':\n"))
-        click.echo('\n'.join(matches))
+        click.echo("\n".join(matches))
     else:
         click.echo(failure(f"No matches found for '{prefix}'"))
 
@@ -66,17 +59,14 @@ def find_matches(prefix: str):
 @cli.command(name="set")
 @click.argument("key")
 @click.argument("val")
-def set_value(key: str, val: str):
-    """Sets a DB key to a given value. (Dynamically Typed)"""
-
+def set_value(key: str, val: str) -> None:
+    """Add a given key-value pair to the DB. (Dynamically Typed)."""
     try:
         val = eval(val, {})
         database[key] = val
     except Exception as e:
-        click.echo(
-            failure(f"An error occured while setting DB[{key}] to '{val}'\n")
-        )
-        click.echo(failure(e))
+        click.echo(failure(f"Error occured while setting DB[{key}] to '{val}'"))
+        click.echo(failure(f"\n{e}"))
     else:
         click.echo(success(f"DB[{key}] was successfully set to '{val}'"))
         click.echo(info(f"Dynamically typed to {type(val)}"))
@@ -84,16 +74,16 @@ def set_value(key: str, val: str):
 
 @cli.command(name="del")
 @click.argument("key")
-def del_value(key: str):
-    """Deletes the key-value pair of the given key."""
-
+def del_value(key: str) -> None:
+    """Delete the key-value pair located at the given key."""
     try:
         val = database[key]
     except KeyError:
         click.echo(failure(f"The key '{key}' was not found in the DB."))
     else:
         click.echo(success(f"The value '{val}' was found at db['{key}']"))
-        flag = str(input("Confirm delete? (y/n): "))
+        flag = click.prompt(failure("Confirm delete? (y/n)"))
+        flag = str(flag)
         click.echo()
 
         if flag == "y":
@@ -104,13 +94,14 @@ def del_value(key: str):
 
 
 @cli.command(name="nuke")
-def nuke_db():
-    """Wipes ALL key-value pairs in the DB."""
-
-    flag = str(input("Are you sure you want to nuke the DB? (y/n):"))
+def nuke_db() -> None:
+    """Wipe ALL key-value pairs in the DB."""
+    flag = click.prompt(failure("Are you sure you want to nuke the DB? (y/n)"))
+    flag = str(flag)
 
     if flag == "y":
-        flag = str(input("Ok, but like, REALLY sure? (y/n):"))
+        flag = click.prompt(failure("Ok, but like, REALLY sure? (y/n)"))
+        flag = str(flag)
 
         if flag == "y":
             click.echo(info("Beginning Nuke operation...\n"))
@@ -128,11 +119,10 @@ def nuke_db():
 
 @cli.command(name="all")
 @click.argument("file_path", default="db_all.json")
-def list_all(file_path: str):
-    """Writes all keys and values in the DB to a JSON file."""
-
+def list_all(file_path: str) -> None:
+    """Write all keys and values in the DB to a JSON file."""
     try:
-        file = open(file_path, 'w+')
+        file = open(file_path, "w+")
     except FileNotFoundError:
         click.echo(failure(f"No such file or directory '{file_path}'"))
     else:

--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -1,7 +1,21 @@
 import json
 import click
 
+import replit.termutils as term
 from replit import db as database
+
+
+def wrap(color: term.Color, value: str):
+    return color.fg + value + term.reset
+
+
+def success(value: str):
+    return term.brightgreen.fg + value + term.reset
+
+
+def failure(value: str):
+    return term.brightred.fg + value + term.reset
+
 
 def chunk(lst: list, n: int):
     for i in range(0, len(lst), n):
@@ -34,10 +48,10 @@ def find_matches(prefix: str):
     matches = list(database.prefix(prefix))
 
     if matches:
-        click.echo(f"Matches found for '{prefix}':\n")
+        click.echo(success(f"Matches found for '{prefix}':\n"))
         click.echo('\n'.join(matches))
     else:
-        click.echo(f"No matches found for '{prefix}'")
+        click.echo(failure(f"No matches found for '{prefix}'"))
 
 
 @cli.command(name="set")
@@ -50,9 +64,9 @@ def set_value(key: str, val: str):
     try:
         database[key] = val
     except:
-        click.echo(f"An error occured while setting DB[{key}] to '{val}'")
+        click.echo(failure(f"An error occured while setting DB[{key}] to '{val}'"))
 
-    click.echo(f"DB[{key}] was successfully set to '{val}'")
+    click.echo(success(f"DB[{key}] was successfully set to '{val}'"))
 
 
 @cli.command(name="all")
@@ -66,8 +80,8 @@ def list_all(file_path: str):
     
     json.dump(binds, file)
 
-    click.echo(f"Ouput successfully dumped to '{file_path}'")
+    click.echo(success(f"Ouput successfully dumped to '{file_path}'"))
 
 
 if __name__ == "__main__":
-    cli(prog_name="db")
+    cli(prog_name="repldb")

--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -1,3 +1,4 @@
+import os
 import json
 import click
 
@@ -7,6 +8,10 @@ from replit import db as database
 
 def wrap(color: term.Color, value: str):
     return color.fg + value + term.reset
+
+
+def info(value: str):
+    return term.brightblue.fg + value + term.reset
 
 
 def success(value: str):
@@ -33,11 +38,15 @@ def cli():
 def list_keys(file_path: str):
     """Writes all keys in the DB to a JSON file."""
 
-    file = open(file_path, 'w+')
+    try:
+        file = open(file_path, 'w+')
+    except:
+        click.echo(failure(f"No such file or directory '{file_path}'"))
+    
     keys = list(database.keys())
     json.dump(keys, file)
 
-    click.echo(f"Ouput successfully dumped to '{file_path}'")
+    click.echo(success(f"Ouput successfully dumped to '{file_path}'"))
 
 
 @cli.command(name="match")
@@ -59,14 +68,62 @@ def find_matches(prefix: str):
 @click.argument("val")
 def set_value(key: str, val: str):
     """Sets a DB key to a given value. (Dynamically Typed)"""
-
-    val = eval(val, {})
+        
     try:
+        val = eval(val, {})
         database[key] = val
     except:
         click.echo(failure(f"An error occured while setting DB[{key}] to '{val}'"))
+    else:
+        click.echo(success(f"DB[{key}] was successfully set to '{val}'"))
+        click.echo(info(f"Dynamically typed to {type(val)}"))
 
-    click.echo(success(f"DB[{key}] was successfully set to '{val}'"))
+
+@cli.command(name="del")
+@click.argument("key")
+def del_value(key: str):
+    """Deletes the key-value pair of the given key."""
+
+    try:
+        val = database[key]
+    except KeyError:
+        click.echo(failure(f"The key '{key}' was not found in the DB."))
+    else:
+        click.echo(success(f"The value '{val}' was found at db['{key}']"))
+        flag = str(input("Confirm delete? (y/n): "))
+        click.echo()
+
+        if flag == "y":
+            del database[key]
+            click.echo(success(f"db['{key}'] was successfully deleted."))
+        else:
+            click.echo(info(f"Delete operation cancelled."))
+
+
+@cli.command(name="nuke")
+def nuke_db():
+    """Wipes ALL key-value pairs in the DB."""
+
+    if os.getenv("is_admin", default=False):
+        flag = str(input("Are you sure you want to nuke the DB? (y/n):"))
+
+        if flag == "y":
+            flag = str(input("Ok, but like, REALLY sure? (y/n):"))
+
+            if flag == "y":
+                click.echo(info("Beginning Nuke operation...\n"))
+
+                keys = list(database.keys())
+                for k in keys: del database[k]
+
+                click.echo(success("Nuke operation successful."))
+            else:
+                click.echo(info("Nuke operation cancelled. (close one!)"))
+        else:
+            click.echo(info("Nuke operation cancelled."))        
+    else:
+        click.echo(failure("Only repl owners have access to this command."))
+
 
 
 @cli.command(name="all")
@@ -74,13 +131,17 @@ def set_value(key: str, val: str):
 def list_all(file_path: str):
     """Writes all keys and values in the DB to a JSON file."""
 
-    file = open(file_path, 'w+')
-    keys = list(database.keys())
-    binds = dict([(k, database[k]) for k in keys])
-    
-    json.dump(binds, file)
+    try:
+        file = open(file_path, 'w+')
+    except:
+        click.echo(failure(f"No such file or directory '{file_path}'"))
+    else:
+        keys = list(database.keys())
+        binds = dict([(k, database[k]) for k in keys])
+        
+        json.dump(binds, file)
 
-    click.echo(success(f"Ouput successfully dumped to '{file_path}'"))
+        click.echo(success(f"Output successfully dumped to '{file_path}'"))
 
 
 if __name__ == "__main__":

--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -2,7 +2,6 @@
 import json
 
 import click
-
 from replit import db as database
 from replit import termutils as term
 

--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -59,9 +59,8 @@ def find_matches(prefix: str) -> None:
 @click.argument("key")
 @click.argument("val")
 def set_value(key: str, val: str) -> None:
-    """Add a given key-value pair to the DB. (Dynamically Typed)."""
+    """Add a given key-value pair to the DB."""
     try:
-        val = eval(val, {})
         database[key] = val
     except Exception as e:
         click.echo(failure(f"Error occured while setting DB[{key}] to '{val}'"))

--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -1,4 +1,4 @@
-"""CLI for interacting with your Repl's DB. Written as top-level script to be run from a shell."""
+"""CLI for interacting with your Repl's DB. Written as top-level script."""
 import json
 
 import click

--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -1,0 +1,73 @@
+import json
+import click
+
+from replit import db as database
+
+def chunk(lst: list, n: int):
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
+
+
+@click.group()
+@click.version_option("0.0.1")
+def cli():
+    """CLI for interacting with your Repl's DB."""
+
+
+@cli.command(name="keys")
+@click.argument("file_path", default="db_keys.json")
+def list_keys(file_path: str):
+    """Writes all keys in the DB to a JSON file."""
+
+    file = open(file_path, 'w+')
+    keys = list(database.keys())
+    json.dump(keys, file)
+
+    click.echo(f"Ouput successfully dumped to '{file_path}'")
+
+
+@cli.command(name="match")
+@click.argument("prefix")
+def find_matches(prefix: str):
+    """Finds keys with a given prefix."""
+
+    matches = list(database.prefix(prefix))
+
+    if matches:
+        click.echo(f"Matches found for '{prefix}':\n")
+        click.echo('\n'.join(matches))
+    else:
+        click.echo(f"No matches found for '{prefix}'")
+
+
+@cli.command(name="set")
+@click.argument("key")
+@click.argument("val")
+def set_value(key: str, val: str):
+    """Sets a DB key to a given value. (Dynamically Typed)"""
+
+    val = eval(val, {})
+    try:
+        database[key] = val
+    except:
+        click.echo(f"An error occured while setting DB[{key}] to '{val}'")
+
+    click.echo(f"DB[{key}] was successfully set to '{val}'")
+
+
+@cli.command(name="all")
+@click.argument("file_path", default="db_all.json")
+def list_all(file_path: str):
+    """Writes all keys and values in the DB to a JSON file."""
+
+    file = open(file_path, 'w+')
+    keys = list(database.keys())
+    binds = dict([(k, database[k]) for k in keys])
+    
+    json.dump(binds, file)
+
+    click.echo(f"Ouput successfully dumped to '{file_path}'")
+
+
+if __name__ == "__main__":
+    cli(prog_name="db")

--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -1,9 +1,9 @@
-import os
 import json
+
 import click
 
-import replit.termutils as term
 from replit import db as database
+import replit.termutils as term
 
 
 def wrap(color: term.Color, value: str):
@@ -40,7 +40,7 @@ def list_keys(file_path: str):
 
     try:
         file = open(file_path, 'w+')
-    except:
+    except FileNotFoundError:
         click.echo(failure(f"No such file or directory '{file_path}'"))
     else:
         keys = list(database.keys())
@@ -68,12 +68,15 @@ def find_matches(prefix: str):
 @click.argument("val")
 def set_value(key: str, val: str):
     """Sets a DB key to a given value. (Dynamically Typed)"""
-        
+
     try:
         val = eval(val, {})
         database[key] = val
-    except:
-        click.echo(failure(f"An error occured while setting DB[{key}] to '{val}'"))
+    except Exception as e:
+        click.echo(
+            failure(f"An error occured while setting DB[{key}] to '{val}'\n")
+        )
+        click.echo(failure(e))
     else:
         click.echo(success(f"DB[{key}] was successfully set to '{val}'"))
         click.echo(info(f"Dynamically typed to {type(val)}"))
@@ -97,7 +100,7 @@ def del_value(key: str):
             del database[key]
             click.echo(success(f"db['{key}'] was successfully deleted."))
         else:
-            click.echo(info(f"Delete operation cancelled."))
+            click.echo(info("Delete operation cancelled."))
 
 
 @cli.command(name="nuke")
@@ -111,16 +114,16 @@ def nuke_db():
 
         if flag == "y":
             click.echo(info("Beginning Nuke operation...\n"))
-
             keys = list(database.keys())
-            for k in keys: del database[k]
+
+            for k in keys:
+                del database[k]
 
             click.echo(success("Nuke operation successful."))
         else:
             click.echo(info("Nuke operation cancelled. (close one!)"))
     else:
-        click.echo(info("Nuke operation cancelled."))        
-
+        click.echo(info("Nuke operation cancelled."))
 
 
 @cli.command(name="all")
@@ -130,12 +133,12 @@ def list_all(file_path: str):
 
     try:
         file = open(file_path, 'w+')
-    except:
+    except FileNotFoundError:
         click.echo(failure(f"No such file or directory '{file_path}'"))
     else:
         keys = list(database.keys())
         binds = dict([(k, database[k]) for k in keys])
-        
+
         json.dump(binds, file)
 
         click.echo(success(f"Output successfully dumped to '{file_path}'"))

--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -1,4 +1,4 @@
-"""CLI for interacting with your Repl's DB. Written as top-level script."""
+"""CLI for interacting with your Repl's DB. Written as top-level script to be run from a shell."""
 import json
 
 import click

--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -42,11 +42,11 @@ def list_keys(file_path: str):
         file = open(file_path, 'w+')
     except:
         click.echo(failure(f"No such file or directory '{file_path}'"))
-    
-    keys = list(database.keys())
-    json.dump(keys, file)
+    else:
+        keys = list(database.keys())
+        json.dump(keys, file)
 
-    click.echo(success(f"Ouput successfully dumped to '{file_path}'"))
+        click.echo(success(f"Ouput successfully dumped to '{file_path}'"))
 
 
 @cli.command(name="match")
@@ -104,25 +104,22 @@ def del_value(key: str):
 def nuke_db():
     """Wipes ALL key-value pairs in the DB."""
 
-    if os.getenv("is_admin", default=False):
-        flag = str(input("Are you sure you want to nuke the DB? (y/n):"))
+    flag = str(input("Are you sure you want to nuke the DB? (y/n):"))
+
+    if flag == "y":
+        flag = str(input("Ok, but like, REALLY sure? (y/n):"))
 
         if flag == "y":
-            flag = str(input("Ok, but like, REALLY sure? (y/n):"))
+            click.echo(info("Beginning Nuke operation...\n"))
 
-            if flag == "y":
-                click.echo(info("Beginning Nuke operation...\n"))
+            keys = list(database.keys())
+            for k in keys: del database[k]
 
-                keys = list(database.keys())
-                for k in keys: del database[k]
-
-                click.echo(success("Nuke operation successful."))
-            else:
-                click.echo(info("Nuke operation cancelled. (close one!)"))
+            click.echo(success("Nuke operation successful."))
         else:
-            click.echo(info("Nuke operation cancelled."))        
+            click.echo(info("Nuke operation cancelled. (close one!)"))
     else:
-        click.echo(failure("Only repl owners have access to this command."))
+        click.echo(info("Nuke operation cancelled."))        
 
 
 


### PR DESCRIPTION
Uses [`click`](https://click.palletsprojects.com/en/7.x/) to implement a simple CLI that allows users to interact with their Repl's DB from the shell / command line. Currently has 4 commands, I forgot to add the nuke command before opening the PR :| 

It also uses `replit.py`'s own termutils for coloring! The screenshot below is the interactive example I wrote up which you can find [at this Repl](https://repl.it/@IreTheKID/Repl-DB-CLI#main.py).

![screenshot](https://storage.googleapis.com/replit/images/1607439789089_69df4b0d170e92d1ba67e05387a837f1.png)