### PR TITLE
Add simple import utility for repls

### DIFF
--- a/src/replit/__init__.py
+++ b/src/replit/__init__.py
@@ -1,4 +1,7 @@
 """The replit python module."""
+import sys
+import types
+
 from . import maqpy
 from . import termutils
 from .audio import Audio
@@ -8,6 +11,20 @@ from .database import db
 def clear() -> None:
     """Clear the terminal."""
     print("\033[H\033[2J", end="", flush=True)
+
+    
+def imported() -> list:
+    i = []
+
+    for name, value in globals().items():
+        if isinstance(value, types.ModuleType):
+            i.append(value.__name__)
+    
+    return sorted(i)
+
+
+def importable() -> list:
+    return sorted([i.__name__ for i in sys.modules.values() if i])
 
 
 audio = Audio()


### PR DESCRIPTION
Adds two functions: `imported()` and `importable()`

`imported`: Returns a `list` of module/package names that have been imported in any file of the repl.
`importable`: Returns a `list` of module/package names that are *able* to be imported in any file of the repl.
