### PR TITLE
change secret name

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,7 +8,7 @@ blocks:
   - name: Lint and test
     task:
       secrets:
-        - name: Repl.it Database
+        - name: replit-database
       jobs:
         - name: flake8
           commands:


### PR DESCRIPTION
Parts of Semaphore don't like that there was a space in the name. I renamed it so this isn't a problem anymore.