### PR TITLE
Add close method to synchronous DB client

### DIFF
--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -252,3 +252,6 @@ class Database(abc.MutableMapping):
             A string representation of the database object.
         """
         return f"<{self.__class__.__name__}(db_url={self.db_url!r})>"
+
+    def close(self) -> None:
+        self.sess.close()

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -254,4 +254,5 @@ class Database(abc.MutableMapping):
         return f"<{self.__class__.__name__}(db_url={self.db_url!r})>"
 
     def close(self) -> None:
+        """Closes the database client connection."""
         self.sess.close()


### PR DESCRIPTION
This prevents "unclosed socket" warnings. Need to update the tests to use this too.