### PR TITLE
Add alias to utils

### DIFF
--- a/src/replit/web/utils.py
+++ b/src/replit/web/utils.py
@@ -65,6 +65,9 @@ def authenticated(func: Callable = None, login_res: str = sign_in_page) -> Calla
         return decorator
 
 
+needs_sign_in = authenticated
+
+
 def params(
     *param_names: str,
     src: Union[str, dict] = "form",


### PR DESCRIPTION
The name of the `authenticated` decorator was changed in #34. This PR adds an alias to the old name to help with backwards compatibility. 

This fixes the root cause of 1bd971a in #39.