### PR TITLE
Add support for nested setting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 select = ANN,B,B9,BLK,C,D,DAR,E,F,I,S,W
-ignore = E203,W503,ANN101,ANN102,S322,ANN206,S201
+ignore = E203,W503,ANN101,ANN102,S322,ANN206,S201,D105,D107
 per-file-ignores =
     src/replit/__init__.py:F401
     src/replit/web/__init__.py:F401

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -2,7 +2,7 @@
 
 from collections import abc
 import json
-from typing import AbstractSet, Any, Callable, Dict, Iterator, List, Tuple
+from typing import AbstractSet, Any, Callable, Dict, Iterator, List, Optional, Tuple
 import urllib
 
 import aiohttp
@@ -145,9 +145,14 @@ class ObservedList(abc.MutableSequence):
 
     __slots__ = ("on_mutate", "value")
 
-    def __init__(self, on_mutate: Callable[[List], None], value: List = []) -> None:
+    def __init__(
+        self, on_mutate: Callable[[List], None], value: Optional[List] = None
+    ) -> None:
         self.on_mutate = on_mutate
-        self.value = value
+        if self.value is None:
+            self.value = []
+        else:
+            self.value = value
 
     def __getitem__(self, i: int) -> Any:
         return self.value[i]
@@ -185,9 +190,14 @@ class ObservedDict(abc.MutableMapping):
 
     __slots__ = ("on_mutate", "value")
 
-    def __init__(self, on_mutate: Callable[[List], None], value: Dict = {}) -> None:
+    def __init__(
+        self, on_mutate: Callable[[List], None], value: Optional[Dict] = None
+    ) -> None:
         self.on_mutate = on_mutate
-        self.value = value
+        if self.value is None:
+            self.value = []
+        else:
+            self.value = value
 
     def __contains__(self, k: Any) -> bool:
         return k in self.value

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -204,9 +204,6 @@ class ObservedList(list):
         except TypeError:
             return result
 
-    def __getslice__(self, i: Any, j: Any) -> Any:
-        return self._reinit(self._on_mutate_handler, super().__getslice__(i, j))
-
     def __getitem__(self, i: Union[int, slice]) -> Any:
         return self._try_reinit(super().__getitem__(i))
 
@@ -218,13 +215,13 @@ class ObservedList(list):
         super().__delitem__(i)
         self.on_mutate()
 
-    def __iadd__(self, rhs: Any) -> Any:
+    def __iadd__(self, rhs: Any) -> Any:  # type: ignore
         # same as extend
         super().__iadd__(self._try_reinit(rhs))
         self.on_mutate()
         return self
 
-    def __imul__(self, rhs: Any) -> Any:
+    def __imul__(self, rhs: Any) -> Any:  # type: ignore
         super().__imul__(self._try_reinit(rhs))
         self.on_mutate()
         return self
@@ -254,7 +251,7 @@ class ObservedList(list):
         super().insert(i, self._try_reinit(x))
         self.on_mutate()
 
-    def pop(self, i: Any) -> Any:
+    def pop(self, i: Any) -> Any:  # type: ignore
         """Refer to the list documentation for information this method."""
         val = super().pop(i)
         self.on_mutate()
@@ -310,7 +307,7 @@ class ObservedDict(dict):
         super().__delitem__(k)
         self.on_mutate()
 
-    def get(self, k: Any, default: Any = None) -> None:
+    def get(self, k: Any, default: Any = None) -> Any:
         """Refer to the dictionary documentation for information this method."""
         return super().get(k, default)
 
@@ -329,9 +326,9 @@ class ObservedDict(dict):
         self.on_mutate()
         return val
 
-    def update(self, mapping: Any = (), **kwargs: Any) -> None:
+    def update(self, mapping: Any = (), **kwargs: Any) -> None:  # type: ignore
         """Refer to the dictionary documentation for information this method."""
-        super().update(self._process_args(mapping, **kwargs))
+        super().update(mapping, **kwargs)
         self.on_mutate()
 
     def __contains__(self, k: Any) -> bool:
@@ -339,7 +336,7 @@ class ObservedDict(dict):
 
     def copy(self) -> Any:  # don't delegate w/ super - dict.copy() -> dict
         """Refer to the dictionary documentation for information this method."""
-        return type(self)(self)
+        return type(self)(self._on_mutate_handler, super().copy())
 
     @classmethod
     def fromkeys(cls, keys: Any, v: Any = None) -> Any:

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -404,7 +404,7 @@ class Database(abc.MutableMapping):
         r.raise_for_status()
 
         val = json.loads(r.text)
-        return item_to_observed(_get_set_cb(self, k), val)
+        return item_to_observed(_get_set_cb(self, key), val)
 
     def __setitem__(self, key: str, value: Any) -> None:
         """Set a key in the database to value.

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -140,7 +140,7 @@ class AsyncDatabase:
         return f"<{self.__class__.__name__}(db_url={self.db_url!r})>"
 
 
-class DatabaseList(abc.MutableSequence):
+class ObservedList(abc.MutableSequence):
     """A list that calls a function every time it is mutated."""
 
     __slots__ = ("on_mutate", "value")
@@ -177,7 +177,7 @@ class DatabaseList(abc.MutableSequence):
         self.on_mutate(self.value)
 
 
-class DatabaseDict(abc.MutableMapping):
+class ObservedDict(abc.MutableMapping):
     """A list that calls a function every time it is mutated."""
 
     __slots__ = ("on_mutate", "value")

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -149,7 +149,7 @@ class ObservedList(abc.MutableSequence):
         self, on_mutate: Callable[[List], None], value: Optional[List] = None
     ) -> None:
         self.on_mutate = on_mutate
-        if self.value is None:
+        if value is None:
             self.value = []
         else:
             self.value = value
@@ -194,7 +194,7 @@ class ObservedDict(abc.MutableMapping):
         self, on_mutate: Callable[[List], None], value: Optional[Dict] = None
     ) -> None:
         self.on_mutate = on_mutate
-        if self.value is None:
+        if value is None:
             self.value = []
         else:
             self.value = value

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -2,7 +2,7 @@
 
 from collections import abc
 import json
-from typing import AbstractSet, Any, Callable, Dict, Iterator, Tuple
+from typing import AbstractSet, Any, Callable, Dict, Iterator, List, Tuple
 import urllib
 
 import aiohttp

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -175,9 +175,14 @@ class ObservedList(list):
     def _try_reinit(self, result) -> Any:
         """Tries to iterate over every element in result, recursing on each item.
         If a type-error is raised, returns result unmodified."""
-        if isinstance(result, ObservedList):
+        print("_try_reinit", type(result), result)
+        if isinstance(result, ObservedList) or isinstance(result, str):
             # We assume that all sublists are also ObservedLists.
             # If this condition is not true, bad things will happen
+
+            # strings are a special case: they are iterable but also don't raise a
+            #  TypeError when passed to the constructor, causing an infinite loop,
+            #  so we must catch them.
             return result
         else:
             try:

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -177,6 +177,41 @@ class DatabaseList(abc.MutableSequence):
         self.on_mutate(self.value)
 
 
+class DatabaseDict(abc.MutableMapping):
+    """A list that calls a function every time it is mutated."""
+
+    __slots__ = ("on_mutate", "value")
+
+    def __init__(self, on_mutate: Callable[Dict], value: Dict = {}) -> DatabaseList:
+        self.on_mutate = on_mutate
+        self.value = value
+
+    def __contains__(self, k: Any) -> bool:
+        return k in self.value
+
+    def __getitem__(self, k: Any) -> Any:
+        return self.value[k]
+
+    def __setitem__(self, k: Any, v: Any) -> None:
+        self.value[k] = v
+        self.on_mutate(self.value)
+
+    def __delitem__(self, k: Any) -> None:
+        del self.value[k]
+        self.on_mutate(self.value)
+
+    def __iter__(self) -> Iterable[Any]:
+        return iter(self.value)
+
+    def __len__(self) -> int:
+        return len(self.value)
+
+    def set_value(self, value: List) -> None:
+        """Sets the value attribute and triggers the mutation function."""
+        self.value = value
+        self.on_mutate(self.value)
+
+
 class Database(abc.MutableMapping):
     """Dictionary-like interface for Repl.it Database.
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -232,7 +232,8 @@ def item_to_observed(on_mutate: Callable[[Any], None], item: Any) -> Any:
     """Takes a JSON value and recursively converts it into an Observed value."""
     # Bind on_mutate to the item it was called on.
     # If this is a recursive call, item will be ignored (passed into the _ param)
-    cb = lambda _: on_mutate(item)
+    def cb(_: Any) -> None:
+        on_mutate(item)
 
     if isinstance(item, str) or isinstance(item, int) or item is None:
         return item

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -145,7 +145,9 @@ class ObservedList(abc.MutableSequence):
 
     __slots__ = ("on_mutate", "value")
 
-    def __init__(self, on_mutate: Callable[List], value: List = []) -> DatabaseList:
+    def __init__(
+        self, on_mutate: Callable[[List], None], value: List = []
+    ) -> DatabaseList:
         self.on_mutate = on_mutate
         self.value = value
 
@@ -182,7 +184,9 @@ class ObservedDict(abc.MutableMapping):
 
     __slots__ = ("on_mutate", "value")
 
-    def __init__(self, on_mutate: Callable[Dict], value: Dict = {}) -> DatabaseList:
+    def __init__(
+        self, on_mutate: Callable[[List], None], value: Dict = {}
+    ) -> DatabaseList:
         self.on_mutate = on_mutate
         self.value = value
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -145,9 +145,7 @@ class ObservedList(abc.MutableSequence):
 
     __slots__ = ("on_mutate", "value")
 
-    def __init__(
-        self, on_mutate: Callable[[List], None], value: List = []
-    ) -> ObservedList:
+    def __init__(self, on_mutate: Callable[[List], None], value: List = []) -> None:
         self.on_mutate = on_mutate
         self.value = value
 
@@ -184,9 +182,7 @@ class ObservedDict(abc.MutableMapping):
 
     __slots__ = ("on_mutate", "value")
 
-    def __init__(
-        self, on_mutate: Callable[[List], None], value: Dict = {}
-    ) -> ObservedDict:
+    def __init__(self, on_mutate: Callable[[List], None], value: Dict = {}) -> None:
         self.on_mutate = on_mutate
         self.value = value
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -176,6 +176,9 @@ class ObservedList(abc.MutableSequence):
         self.value = value
         self.on_mutate(self.value)
 
+    def __repr__(self) -> str:
+        return f"{self.__name__}({self.value!r})"
+
 
 class ObservedDict(abc.MutableMapping):
     """A list that calls a function every time it is mutated."""
@@ -210,6 +213,9 @@ class ObservedDict(abc.MutableMapping):
         """Sets the value attribute and triggers the mutation function."""
         self.value = value
         self.on_mutate(self.value)
+
+    def __repr__(self) -> str:
+        return f"{self.__name__}({self.value!r})"
 
 
 class Database(abc.MutableMapping):

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -147,7 +147,7 @@ class ObservedList(abc.MutableSequence):
 
     def __init__(
         self, on_mutate: Callable[[List], None], value: List = []
-    ) -> DatabaseList:
+    ) -> ObservedList:
         self.on_mutate = on_mutate
         self.value = value
 
@@ -186,7 +186,7 @@ class ObservedDict(abc.MutableMapping):
 
     def __init__(
         self, on_mutate: Callable[[List], None], value: Dict = {}
-    ) -> DatabaseList:
+    ) -> ObservedDict:
         self.on_mutate = on_mutate
         self.value = value
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -177,7 +177,7 @@ class ObservedList(abc.MutableSequence):
         self.on_mutate(self.value)
 
     def __repr__(self) -> str:
-        return f"{self.__name__}(value={self.value!r})"
+        return f"{type(self).__name__}(value={self.value!r})"
 
 
 class ObservedDict(abc.MutableMapping):
@@ -215,7 +215,7 @@ class ObservedDict(abc.MutableMapping):
         self.on_mutate(self.value)
 
     def __repr__(self) -> str:
-        return f"{self.__name__}(value={self.value!r})"
+        return f"{type(self).__name__}(value={self.value!r})"
 
 
 class Database(abc.MutableMapping):

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -163,6 +163,9 @@ class DatabaseList(abc.MutableSequence):
     def __len__(self) -> int:
         return len(self.value)
 
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self.value)
+
     def insert(self, i: int, elem: Any) -> None:
         """Inserts a value into the underlying list."""
         self.value.insert(i, elem)

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -339,7 +339,7 @@ def item_to_observed(on_mutate: Callable[[Any], None], item: Any) -> Any:
     elif isinstance(item, dict):
         # no-op handler so we don't call on_mutate in the loop below
         d = ObservedDict((lambda _: None), item)
-        cb = _get_cb(d)
+        cb = _get_on_mutate_cb(d)
 
         for k, v in item.items():
             d[k] = item_to_observed(cb, v)

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -2,7 +2,7 @@
 
 from collections import abc
 import json
-from typing import AbstractSet, Any, Dict, Iterator, Tuple
+from typing import AbstractSet, Any, Callable, Dict, Iterator, Tuple
 import urllib
 
 import aiohttp

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -177,7 +177,7 @@ class ObservedList(abc.MutableSequence):
         self.on_mutate(self.value)
 
     def __repr__(self) -> str:
-        return f"{self.__name__}({self.value!r})"
+        return f"{self.__name__}(value={self.value!r})"
 
 
 class ObservedDict(abc.MutableMapping):
@@ -215,7 +215,7 @@ class ObservedDict(abc.MutableMapping):
         self.on_mutate(self.value)
 
     def __repr__(self) -> str:
-        return f"{self.__name__}({self.value!r})"
+        return f"{self.__name__}(value={self.value!r})"
 
 
 class Database(abc.MutableMapping):

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -140,6 +140,40 @@ class AsyncDatabase:
         return f"<{self.__class__.__name__}(db_url={self.db_url!r})>"
 
 
+class DatabaseList(abc.MutableSequence):
+    """A list that calls a function every time it is mutated."""
+
+    __slots__ = ("on_mutate", "value")
+
+    def __init__(self, on_mutate: Callable[List], value: List = []) -> DatabaseList:
+        self.on_mutate = on_mutate
+        self.value = value
+
+    def __getitem__(self, i: int) -> Any:
+        return self.value[i]
+
+    def __setitem__(self, i: int, val: Any) -> None:
+        self.value[i] = val
+        self.on_mutate(self.value)
+
+    def __delitem__(self, i: int) -> None:
+        del self.value[i]
+        self.on_mutate(self.value)
+
+    def __len__(self) -> int:
+        return len(self.value)
+
+    def insert(self, i: int, elem: Any) -> None:
+        """Inserts a value into the underlying list."""
+        self.value.insert(i, elem)
+        self.on_mutate(self.value)
+
+    def set_value(self, value: List) -> None:
+        """Sets the value attribute and triggers the mutation function."""
+        self.value = value
+        self.on_mutate(self.value)
+
+
 class Database(abc.MutableMapping):
     """Dictionary-like interface for Repl.it Database.
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -150,7 +150,7 @@ class AsyncDatabase:
         return f"<{self.__class__.__name__}(db_url={self.db_url!r})>"
 
 
-class ObservedList(abc.MutableSequence):
+class ObservedList(abc.MutableSequence, json.JSONEncoder):
     """A list that calls a function every time it is mutated."""
 
     __slots__ = ("on_mutate", "value")
@@ -191,11 +191,15 @@ class ObservedList(abc.MutableSequence):
         self.value = value
         self.on_mutate(self.value)
 
+    def default(self, o: Any) -> List:
+        """Used by JSONEncoder to encode the class as JSON."""
+        return o.value
+
     def __repr__(self) -> str:
         return f"{type(self).__name__}(value={self.value!r})"
 
 
-class ObservedDict(abc.MutableMapping):
+class ObservedDict(abc.MutableMapping, json.JSONEncoder):
     """A list that calls a function every time it is mutated."""
 
     __slots__ = ("on_mutate", "value")
@@ -233,6 +237,10 @@ class ObservedDict(abc.MutableMapping):
         """Sets the value attribute and triggers the mutation function."""
         self.value = value
         self.on_mutate(self.value)
+
+    def default(self, o: Any) -> Dict:
+        """Used by JSONEncoder to encode the class as JSON."""
+        return o.value
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(value={self.value!r})"

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -200,7 +200,7 @@ class ObservedDict(abc.MutableMapping):
         del self.value[k]
         self.on_mutate(self.value)
 
-    def __iter__(self) -> Iterable[Any]:
+    def __iter__(self) -> Iterator[Any]:
         return iter(self.value)
 
     def __len__(self) -> int:

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -231,7 +231,7 @@ class ObservedList(list):
         return val
 
     def remove(self, x: Any) -> None:
-        # No need to reinit here because ObservableList([1]) == [1]
+        # No need to reinit here because ObservedList([1]) == [1]
         super().remove(x)
         self.on_mutate()
 
@@ -404,7 +404,7 @@ class Database(abc.MutableMapping):
         r.raise_for_status()
 
         val = json.loads(r.text)
-        return item_to_observable(_get_set_cb(self, k), val)
+        return item_to_observed(_get_set_cb(self, k), val)
 
     def __setitem__(self, key: str, value: Any) -> None:
         """Set a key in the database to value.

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -2,7 +2,17 @@
 
 from collections import abc
 import json
-from typing import AbstractSet, Any, Callable, Dict, Iterator, List, Optional, Tuple
+from typing import (
+    AbstractSet,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 import urllib
 
 import aiohttp
@@ -154,14 +164,14 @@ class ObservedList(abc.MutableSequence):
         else:
             self.value = value
 
-    def __getitem__(self, i: int) -> Any:
+    def __getitem__(self, i: Union[int, slice]) -> Any:
         return self.value[i]
 
-    def __setitem__(self, i: int, val: Any) -> None:
+    def __setitem__(self, i: Union[int, slice], val: Any) -> None:
         self.value[i] = val
         self.on_mutate(self.value)
 
-    def __delitem__(self, i: int) -> None:
+    def __delitem__(self, i: Union[int, slice]) -> None:
         del self.value[i]
         self.on_mutate(self.value)
 
@@ -191,11 +201,11 @@ class ObservedDict(abc.MutableMapping):
     __slots__ = ("on_mutate", "value")
 
     def __init__(
-        self, on_mutate: Callable[[List], None], value: Optional[Dict] = None
+        self, on_mutate: Callable[[Dict], None], value: Optional[Dict] = None
     ) -> None:
         self.on_mutate = on_mutate
         if value is None:
-            self.value = []
+            self.value = {}
         else:
             self.value = value
 
@@ -219,7 +229,7 @@ class ObservedDict(abc.MutableMapping):
     def __len__(self) -> int:
         return len(self.value)
 
-    def set_value(self, value: List) -> None:
+    def set_value(self, value: Dict) -> None:
         """Sets the value attribute and triggers the mutation function."""
         self.value = value
         self.on_mutate(self.value)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -196,5 +196,5 @@ class TestDatabase(unittest.TestCase):
 
         db[key] = [1]
         db[key] += [[2, [3, 4]]]
-        db[1][1][1] *= 2
-        self.assertEqual(db[key], [1, [[3, 8]]])
+        db[key][1][1][1] *= 2
+        self.assertEqual(db[key], [1, [2, [3, 8]]])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,6 +14,11 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self) -> None:
         """Grab a JWT for all the tests to share."""
+        self.db = AsyncDatabase(os.environ["REPLIT_DB_URL"])
+        for k in await self.db.keys():
+            await self.db.delete(k)
+        return
+
         password = os.environ["PASSWORD"]
         req = requests.get(
             "https://database-test-jwt.kochman.repl.co", auth=("test", password)
@@ -96,6 +101,9 @@ class TestDatabase(unittest.TestCase):
 
     def setUp(self) -> None:
         """Grab a JWT for all the tests to share."""
+        self.db = Database(os.environ["REPLIT_DB_URL"])
+        return
+
         password = os.environ["PASSWORD"]
         req = requests.get(
             "https://database-test-jwt.kochman.repl.co", auth=("test", password)
@@ -160,3 +168,33 @@ class TestDatabase(unittest.TestCase):
         self.db[key] = val
         act = self.db[key]
         self.assertEqual(act, val)
+
+    def test_nested_setting(self) -> None:
+        """Test that nested setting of dictionaries."""
+        db = self.db
+        key = "big-nested-object"
+        val = {"a": {"b": 1}}
+
+        db[key] = val
+        db[key]["a"]["b"] = 5
+        db[key]["a"]["b"] += 2
+        self.assertEqual(db[key], {"a": {"b": 7}})
+
+    def test_nested_lists(self) -> None:
+        """Test that nested setting of lists works."""
+        db = self.db
+        key = "nested-list"
+
+        db[key] = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        db[key][1][1] = 99
+        db[key].append(2)
+        self.assertEqual(db[key], [[1, 2, 3], [4, 99, 6], [7, 8, 9], 2])
+
+        db[key] = [[1, 2]]
+        db[key] *= 2
+        self.assertEqual(db[key], [[1, 2], [1, 2]])
+
+        db[key] = [1]
+        db[key] += [[2, [3, 4]]]
+        db[1][1][1] *= 2
+        self.assertEqual(db[key], [1, [[3, 8]]])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,17 +14,15 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self) -> None:
         """Grab a JWT for all the tests to share."""
-        self.db = AsyncDatabase(os.environ["REPLIT_DB_URL"])
-        for k in await self.db.keys():
-            await self.db.delete(k)
-        return
-
-        password = os.environ["PASSWORD"]
-        req = requests.get(
-            "https://database-test-jwt.kochman.repl.co", auth=("test", password)
-        )
-        url = req.text
-        self.db = AsyncDatabase(url)
+        if "REPLIT_DB_URL" in os.environ:
+            self.db = AsyncDatabase(os.environ["REPLIT_DB_URL"])
+        else:
+            password = os.environ["PASSWORD"]
+            req = requests.get(
+                "https://database-test-jwt.kochman.repl.co", auth=("test", password)
+            )
+            url = req.text
+            self.db = AsyncDatabase(url)
 
         # nuke whatever is already here
         for k in await self.db.keys():
@@ -101,15 +99,15 @@ class TestDatabase(unittest.TestCase):
 
     def setUp(self) -> None:
         """Grab a JWT for all the tests to share."""
-        self.db = Database(os.environ["REPLIT_DB_URL"])
-        return
-
-        password = os.environ["PASSWORD"]
-        req = requests.get(
-            "https://database-test-jwt.kochman.repl.co", auth=("test", password)
-        )
-        url = req.text
-        self.db = Database(url)
+        if "REPLIT_DB_URL" in os.environ:
+            self.db = Database(os.environ["REPLIT_DB_URL"])
+        else:
+            password = os.environ["PASSWORD"]
+            req = requests.get(
+                "https://database-test-jwt.kochman.repl.co", auth=("test", password)
+            )
+            url = req.text
+            self.db = Database(url)
 
         # nuke whatever is already here
         for k in self.db.keys():


### PR DESCRIPTION
Add `ObserableList` and `ObservableDict` classes to the database module which enable nested setting of database keys. 

Closes #26.