### PR TITLE
Add more database API methods

### DIFF
--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -517,8 +517,7 @@ class Database(abc.MutableMapping):
             key (str): The key to set
             value (Any): The value to set it to. Must be JSON-serializable.
         """
-        j = json.dumps(value, separators=(",", ":"))
-        self.set(key, j)
+        self.set(key, value)
 
     def set(self, key: str, value: Any) -> None:
         """Set a key in the database to value, JSON encoding it.

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -34,11 +34,6 @@ class AsyncDatabase:
     async def get(self, key: str) -> str:
         """Return the value for key if key is in the database, else default.
 
-        Will replace the mutable JSON types of dict and list with subclasses that
-        enable nested setting. These classes will block to request the DB on every
-        mutation, which can have performance implications. To disable this, use the
-        `get_raw` method instead.
-
         This method will JSON decode the value. To disable this behavior, use the
         `get_raw` method instead.
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -473,14 +473,23 @@ class Database(abc.MutableMapping):
         return r.text
 
     def __setitem__(self, key: str, value: Any) -> None:
-        """Set a key in the database to value.
+        """Set a key in the database to the result of JSON encoding value.
 
         Args:
             key (str): The key to set
             value (Any): The value to set it to. Must be JSON-serializable.
         """
         j = json.dumps(value, separators=(",", ":"))
-        r = self.sess.post(self.db_url, data={key: j})
+        self.set_raw(key, value)
+
+    def set_raw(self, key: str, value: str) -> None:
+        """Set a key in the database to value.
+
+        Args:
+            key (str): The key to set
+            value (str): The value to set.
+        """
+        r = self.sess.post(self.db_url, data={key: value})
         r.raise_for_status()
 
     def __delitem__(self, key: str) -> None:

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -84,8 +84,25 @@ class AsyncDatabase:
             key (str): The key to set
             value (str): The value to set it to
         """
+        await self.set_bulk_raw({key: value})
+    
+    async def set_bulk(self, values: Dict[str, Any]) -> None:
+        """Set multiple values in the database, JSON encoding them.
+
+        Args:
+            values (Dict[str, Any]): A dictionary of values to put into the dictionary.
+            Values must be JSON serializeable.
+        """
+        await self.set_bulk_raw({k: json.dumps(v) for k, v in values.items()})
+
+    async def set_bulk_raw(self, values: Dict[str, str]) -> None:
+        """Set multiple values in the database.
+
+        Args:
+            values (Dict[str, str]): The key-value pairs to set.
+        """
         async with aiohttp.ClientSession() as session:
-            async with session.post(self.db_url, data={key: value}) as response:
+            async with session.post(self.db_url, data=values) as response:
                 response.raise_for_status()
 
     async def delete(self, key: str) -> None:

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -413,7 +413,8 @@ class Database(abc.MutableMapping):
 
         Will replace the mutable JSON types of dict and list with subclasses that
         enable nested setting. These classes will block to request the DB on every
-        mutation. To disable this behavior, use the `get` method instead.
+        mutation, which can have performance implications. To disable this, use the
+        `get_raw` method instead.
 
         This method will JSON decode the value. To disable this behavior, use the
         `get_raw` method instead.

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -489,7 +489,7 @@ class Database(abc.MutableMapping):
         Returns:
             Any: The the value for key if key is in the database, else default.
         """
-        return super().get(key, item_to_observed(default))
+        return super().get(key, item_to_observed(_get_set_cb(self, key), default))
 
     def get_raw(self, key: str) -> str:
         """Look up the given key in the database and return the corresponding value.

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -18,6 +18,11 @@ import aiohttp
 import requests
 
 
+def _dumps(val: Any) -> str:
+    """JSON encode a value in the smallest way possible."""
+    return json.dumps(val, separators=(",", ":"))
+
+
 class AsyncDatabase:
     """Async interface for Repl.it Database."""
 
@@ -73,7 +78,7 @@ class AsyncDatabase:
             key (str): The key to set
             value (Any): The value to set it to. Must be JSON-serializable.
         """
-        await self.set_raw(key, json.dumps(value))
+        await self.set_raw(key, _dumps(value))
 
     async def set_raw(self, key: str, value: str) -> None:
         """Set a key in the database to value.
@@ -91,7 +96,7 @@ class AsyncDatabase:
             values (Dict[str, Any]): A dictionary of values to put into the dictionary.
                 Values must be JSON serializeable.
         """
-        await self.set_bulk_raw({k: json.dumps(v) for k, v in values.items()})
+        await self.set_bulk_raw({k: _dumps(v) for k, v in values.items()})
 
     async def set_bulk_raw(self, values: Dict[str, str]) -> None:
         """Set multiple values in the database.
@@ -526,7 +531,7 @@ class Database(abc.MutableMapping):
             key (str): The key to set
             value (Any): The value to set.
         """
-        self.set_raw(key, json.dumps(value))
+        self.set_raw(key, _dumps(value))
 
     def set_raw(self, key: str, value: str) -> None:
         """Set a key in the database to value.
@@ -544,7 +549,7 @@ class Database(abc.MutableMapping):
             values (Dict[str, Any]): A dictionary of values to put into the dictionary.
                 Values must be JSON serializeable.
         """
-        self.set_bulk_raw({k: json.dumps(v) for k, v in values.items()})
+        self.set_bulk_raw({k: _dumps(v) for k, v in values.items()})
 
     def set_bulk_raw(self, values: Dict[str, str]) -> None:
         """Set multiple values in the database.

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -491,11 +491,20 @@ class Database(abc.MutableMapping):
         """
         self.set_bulk_raw({key: value})
 
-    def set_bulk_raw(self, values: Dict[str, Any]) -> None:
+    def set_bulk(self, values: Dict[str, Any]) -> None:
+        """Set multiple values in the database, JSON encoding them.
+
+        Args:
+            values (Dict[str, Any]): A dictionary of values to put into the dictionary.
+            Values must be JSON serializeable.
+        """
+        self.set_bulk_raw({k: json.dumps(v) for k, v in values.items()})
+
+    def set_bulk_raw(self, values: Dict[str, str]) -> None:
         """Set multiple values in the database.
 
         Args:
-            values (Dict[str, Any]): The key-value pairs to set.
+            values (Dict[str, str]): The key-value pairs to set.
         """
         r = self.sess.post(self.db_url, data=values)
         r.raise_for_status()

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -32,18 +32,16 @@ class AsyncDatabase:
         self.db_url = db_url
 
     async def get(self, key: str) -> str:
-        """Return the value for key if key is in the database, else default.
+        """Return the value for key if key is in the database.
 
         This method will JSON decode the value. To disable this behavior, use the
         `get_raw` method instead.
 
         Args:
             key (str): The key to retreive
-            default (Any): The default to return if the key is not the database.
-            Defaults to None.
 
         Returns:
-            Any: The the value for key if key is in the database, else default.
+            str: The the value for key if key is in the database.
         """
         return json.loads(await self.get_raw(key))
 
@@ -91,7 +89,7 @@ class AsyncDatabase:
 
         Args:
             values (Dict[str, Any]): A dictionary of values to put into the dictionary.
-            Values must be JSON serializeable.
+                Values must be JSON serializeable.
         """
         await self.set_bulk_raw({k: json.dumps(v) for k, v in values.items()})
 
@@ -464,9 +462,6 @@ class Database(abc.MutableMapping):
         Args:
             key (str): The key to retreive
 
-        Raises:
-            KeyError: Key is not set
-
         Returns:
             Any: The value of the key
         """
@@ -474,7 +469,8 @@ class Database(abc.MutableMapping):
         val = json.loads(raw_val)
         return item_to_observed(_get_set_cb(self, key), val)
 
-    def get(self, key: str, default: Any = None, /) -> Any:
+    # This should be posititional only but flake8 doesn't like that
+    def get(self, key: str, default: Any = None) -> Any:
         """Return the value for key if key is in the database, else default.
 
         Will replace the mutable JSON types of dict and list with subclasses that
@@ -488,7 +484,7 @@ class Database(abc.MutableMapping):
         Args:
             key (str): The key to retreive
             default (Any): The default to return if the key is not the database.
-            Defaults to None.
+                Defaults to None.
 
         Returns:
             Any: The the value for key if key is in the database, else default.
@@ -522,14 +518,14 @@ class Database(abc.MutableMapping):
             value (Any): The value to set it to. Must be JSON-serializable.
         """
         j = json.dumps(value, separators=(",", ":"))
-        self.set(key, value)
-    
+        self.set(key, j)
+
     def set(self, key: str, value: Any) -> None:
         """Set a key in the database to value, JSON encoding it.
 
         Args:
             key (str): The key to set
-            value (str): The value to set.
+            value (Any): The value to set.
         """
         self.set_raw(key, json.dumps(value))
 
@@ -547,7 +543,7 @@ class Database(abc.MutableMapping):
 
         Args:
             values (Dict[str, Any]): A dictionary of values to put into the dictionary.
-            Values must be JSON serializeable.
+                Values must be JSON serializeable.
         """
         self.set_bulk_raw({k: json.dumps(v) for k, v in values.items()})
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -489,7 +489,15 @@ class Database(abc.MutableMapping):
             key (str): The key to set
             value (str): The value to set.
         """
-        r = self.sess.post(self.db_url, data={key: value})
+        self.set_bulk_raw({key: value})
+
+    def set_bulk_raw(self, values: Dict[str, Any]) -> None:
+        """Set multiple values in the database.
+
+        Args:
+            values (Dict[str, Any]): The key-value pairs to set.
+        """
+        r = self.sess.post(self.db_url, data=values)
         r.raise_for_status()
 
     def __delitem__(self, key: str) -> None:

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -32,6 +32,27 @@ class AsyncDatabase:
         self.db_url = db_url
 
     async def get(self, key: str) -> str:
+        """Return the value for key if key is in the database, else default.
+
+        Will replace the mutable JSON types of dict and list with subclasses that
+        enable nested setting. These classes will block to request the DB on every
+        mutation, which can have performance implications. To disable this, use the
+        `get_raw` method instead.
+
+        This method will JSON decode the value. To disable this behavior, use the
+        `get_raw` method instead.
+
+        Args:
+            key (str): The key to retreive
+            default (Any): The default to return if the key is not the database.
+            Defaults to None.
+
+        Returns:
+            Any: The the value for key if key is in the database, else default.
+        """
+        return json.loads(await self.get_raw(key))
+
+    async def get_raw(self, key: str) -> str:
         """Get the value of an item from the database.
 
         Args:

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -85,7 +85,7 @@ class AsyncDatabase:
             value (str): The value to set it to
         """
         await self.set_bulk_raw({key: value})
-    
+
     async def set_bulk(self, values: Dict[str, Any]) -> None:
         """Set multiple values in the database, JSON encoding them.
 
@@ -522,7 +522,16 @@ class Database(abc.MutableMapping):
             value (Any): The value to set it to. Must be JSON-serializable.
         """
         j = json.dumps(value, separators=(",", ":"))
-        self.set_raw(key, value)
+        self.set(key, value)
+    
+    def set(self, key: str, value: Any) -> None:
+        """Set a key in the database to value, JSON encoding it.
+
+        Args:
+            key (str): The key to set
+            value (str): The value to set.
+        """
+        self.set_raw(key, json.dumps(value))
 
     def set_raw(self, key: str, value: str) -> None:
         """Set a key in the database to value.

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -437,6 +437,27 @@ class Database(abc.MutableMapping):
         val = json.loads(r.text)
         return item_to_observed(_get_set_cb(self, key), val)
 
+    def get(self, key: str, default: Any = None, /) -> Any:
+        """Return the value for key if key is in the database, else default.
+
+        Will replace the mutable JSON types of dict and list with subclasses that
+        enable nested setting. These classes will block to request the DB on every
+        mutation, which can have performance implications. To disable this, use the
+        `get_raw` method instead.
+
+        This method will JSON decode the value. To disable this behavior, use the
+        `get_raw` method instead.
+
+        Args:
+            key (str): The key to retreive
+            default (Any): The default to return if the key is not the database.
+            Defaults to None.
+
+        Returns:
+            Any: The the value for key if key is in the database, else default.
+        """
+        return super().get(key, item_to_observed(default))
+
     def __setitem__(self, key: str, value: Any) -> None:
         """Set a key in the database to value.
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -428,13 +428,8 @@ class Database(abc.MutableMapping):
         Returns:
             Any: The value of the key
         """
-        r = self.sess.get(self.db_url + "/" + urllib.parse.quote(key))
-        if r.status_code == 404:
-            raise KeyError(key)
-
-        r.raise_for_status()
-
-        val = json.loads(r.text)
+        raw_val = self.get_raw(key)
+        val = json.loads(raw_val)
         return item_to_observed(_get_set_cb(self, key), val)
 
     def get(self, key: str, default: Any = None, /) -> Any:
@@ -457,6 +452,25 @@ class Database(abc.MutableMapping):
             Any: The the value for key if key is in the database, else default.
         """
         return super().get(key, item_to_observed(default))
+
+    def get_raw(self, key: str) -> str:
+        """Look up the given key in the database and return the corresponding value.
+
+        Args:
+            key (str): The key to look up
+
+        Raises:
+            KeyError: The key is not in the database.
+
+        Returns:
+            str: The value of the key in the database.
+        """
+        r = self.sess.get(self.db_url + "/" + urllib.parse.quote(key))
+        if r.status_code == 404:
+            raise KeyError(key)
+
+        r.raise_for_status()
+        return r.text
 
     def __setitem__(self, key: str, value: Any) -> None:
         """Set a key in the database to value.

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -68,7 +68,16 @@ class AsyncDatabase:
                 response.raise_for_status()
                 return await response.text()
 
-    async def set(self, key: str, value: str) -> None:
+    async def set(self, key: str, value: Any) -> None:
+        """Set a key in the database to the result of JSON encoding value.
+
+        Args:
+            key (str): The key to set
+            value (Any): The value to set it to. Must be JSON-serializable.
+        """
+        await self.set_raw(key, json.dumps(value))
+
+    async def set_raw(self, key: str, value: str) -> None:
         """Set a key in the database to value.
 
         Args:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -111,6 +111,12 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await self.db.get("bulk1"), "val1")
         self.assertEqual(await self.db.get("bulk2"), "val2")
 
+    async def test_bulk_raw(self) -> None:
+        """Test that bulk raw setting works."""
+        await self.db.set_bulk_raw({"bulk1": "val1", "bulk2": "val2"})
+        self.assertEqual(await self.db.get_raw("bulk1"), "val1")
+        self.assertEqual(await self.db.get_raw("bulk2"), "val2")
+
 
 class TestDatabase(unittest.TestCase):
     """Tests for replit.database.Database."""
@@ -232,3 +238,9 @@ class TestDatabase(unittest.TestCase):
         self.db.set_bulk({"bulk1": "val1", "bulk2": "val2"})
         self.assertEqual(self.db["bulk1"], "val1")
         self.assertEqual(self.db["bulk2"], "val2")
+
+    def test_bulk_raw(self) -> None:
+        """Test that bulk raw setting works."""
+        self.db.set_bulk_raw({"bulk1": "val1", "bulk2": "val2"})
+        self.assertEqual(self.db.get_raw("bulk1"), "val1")
+        self.assertEqual(self.db.get_raw("bulk2"), "val2")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -93,6 +93,18 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
         d = await self.db.to_dict()
         self.assertDictEqual(d, {"key1": "value", "key2": "value"})
 
+    async def test_raw(self) -> None:
+        """Test that get_raw and set_raw do not use JSON."""
+        k = "raw_test"
+        await self.db.set(k, "asdf")
+        self.assertEqual(await self.db.get_raw(k), '"asdf"')
+
+        await self.db.set_raw(k, "asdf")
+        self.assertEqual(await self.db.get_raw(k), "asdf")
+
+        await self.db.set(k, {"key": "val"})
+        self.assertEqual(await self.db.get_raw(k), '{"key": "val"}')
+
 
 class TestDatabase(unittest.TestCase):
     """Tests for replit.database.Database."""
@@ -196,3 +208,15 @@ class TestDatabase(unittest.TestCase):
         db[key] += [[2, [3, 4]]]
         db[key][1][1][1] *= 2
         self.assertEqual(db[key], [1, [2, [3, 8]]])
+
+    def test_raw(self) -> None:
+        """Test that get_raw and set_raw do not use JSON."""
+        k = "raw_test"
+        self.db.set(k, "asdf")
+        self.assertEqual(self.db.get_raw(k), '"asdf"')
+
+        self.db.set_raw(k, "asdf")
+        self.assertEqual(self.db.get_raw(k), "asdf")
+
+        self.db.set(k, {"key": "val"})
+        self.assertEqual(self.db.get_raw(k), '{"key": "val"}')

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -105,6 +105,12 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
         await self.db.set(k, {"key": "val"})
         self.assertEqual(await self.db.get_raw(k), '{"key": "val"}')
 
+    async def test_bulk(self) -> None:
+        """Test that bulk setting works."""
+        await self.db.set_bulk({"bulk1": "val1", "bulk2": "val2"})
+        self.assertEqual(await self.db.get("bulk1"), "val1")
+        self.assertEqual(await self.db.get("bulk2"), "val2")
+
 
 class TestDatabase(unittest.TestCase):
     """Tests for replit.database.Database."""
@@ -220,3 +226,9 @@ class TestDatabase(unittest.TestCase):
 
         self.db.set(k, {"key": "val"})
         self.assertEqual(self.db.get_raw(k), '{"key": "val"}')
+
+    def test_bulk(self) -> None:
+        """Test that bulk setting works."""
+        self.db.set_bulk({"bulk1": "val1", "bulk2": "val2"})
+        self.assertEqual(self.db["bulk1"], "val1")
+        self.assertEqual(self.db["bulk2"], "val2")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -103,7 +103,7 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await self.db.get_raw(k), "asdf")
 
         await self.db.set(k, {"key": "val"})
-        self.assertEqual(await self.db.get_raw(k), '{"key": "val"}')
+        self.assertEqual(await self.db.get_raw(k), '{"key":"val"}')
 
     async def test_bulk(self) -> None:
         """Test that bulk setting works."""
@@ -231,7 +231,7 @@ class TestDatabase(unittest.TestCase):
         self.assertEqual(self.db.get_raw(k), "asdf")
 
         self.db.set(k, {"key": "val"})
-        self.assertEqual(self.db.get_raw(k), '{"key": "val"}')
+        self.assertEqual(self.db.get_raw(k), '{"key":"val"}')
 
     def test_bulk(self) -> None:
         """Test that bulk setting works."""


### PR DESCRIPTION
Closes #42.

- Clarify docstring
- Implement get method
- Implement get_raw method
- Implement set_raw method
- Implement the set_bulk_raw method
- Implement set_bulk
- Implement async get_raw
- Implement async set_raw
- Implement async set_bulk and async set_bulk_raw
- Add set method to sync DB
- Add tests for raw operations
- Add tests for bulk setting
- Add tests for bulk raw setting
- flake8 fixes
- Fix mypy errors
