### PR TITLE
Manually JSON decode DB values in CLI dump

### DIFF
--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -3,6 +3,7 @@ import json
 
 import click
 from replit import db as database
+from replit.database import DBJSONEncoder
 
 
 reset = "\u001b[0m"
@@ -94,7 +95,7 @@ def list_all(file_path: str) -> None:
     """Write all keys and values in the DB to a JSON file."""
     with open(file_path, "w") as f:
         keys = list(database.keys())
-        binds = dict([(k, database[k]) for k in keys])
+        binds = dict([(k, json.loads(database.get_raw(k))) for k in keys])
 
         json.dump(binds, f)
 

--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -3,7 +3,6 @@ import json
 
 import click
 from replit import db as database
-from replit.database import DBJSONEncoder
 
 
 reset = "\u001b[0m"


### PR DESCRIPTION
The special DB values can not be dumped, causing a bug. This uses load(get_raw) so that is no longer an issue. Could also just use DBJSONEncoder in the dump cls kwarg, but this is easier and slightly more performant.