### PR TITLE
Bug: Make UserStore iter yield keys

### DIFF
--- a/src/replit/web/user.py
+++ b/src/replit/web/user.py
@@ -90,7 +90,7 @@ class UserStore(Mapping):
     def __iter__(self) -> Iterator[User]:
         for k in db.keys():
             if k.startswith(self.prefix):
-                yield self[self._strip_prefix(k)]
+                yield self._strip_prefix(k)
 
     def __len__(self) -> int:
         return sum(1 for _ in self)


### PR DESCRIPTION
The __iter__ method on a mapping should yield the keys of the mapping instead of values as it was doing before.