### PR TITLE
Fix missing await statement in AsyncDatabase

### DIFF
--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -77,7 +77,7 @@ class AsyncDatabase:
         return self
 
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        self.sess.close()
+        await self.sess.close()
 
     async def get(self, key: str) -> str:
         """Return the value for key if key is in the database.


### PR DESCRIPTION
In [replit/database/database.py, line 80](https://github.com/replit/replit-py/blob/master/src/replit/database/database.py#L80)
From:
```py
        self.sess.close()
```
To:
```py
        await self.sess.close()
```

Should fix #118 