### PR TITLE
Make it compatible with newer packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ documentation = "https://replit-py.readthedocs.org/"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-typing_extensions = "^3.7.4"
+typing_extensions = "^4"
 Flask = "^2.0.0"
 Werkzeug = "^2.0.0"
 aiohttp = "^3.6.2"


### PR DESCRIPTION
Bump typing_extensions to v4, which is what many packages now depend on. Package uses python 3.8, but v4 is only breaking on python<3.6 anyways.