### PR TITLE
Load Replit DB URL from a file

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,21 +16,21 @@ blocks:
           commands:
             - sem-version python 3.8
             - checkout --use-cache
-            - python -m pip install --upgrade poetry
-            - poetry install
+            - pip install poetry==1.3.2 --no-cache
+            - poetry install --no-root --no-interaction --no-ansi
             - poetry run flake8
         - name: unittest
           commands:
             - sem-version python 3.8
             - checkout --use-cache
-            - python -m pip install --upgrade poetry
-            - poetry install
+            - pip install poetry==1.3.2 --no-cache
+            - poetry install --no-root --no-interaction --no-ansi
             - poetry run coverage run -m unittest
             - poetry run coverage report -m --include='src/*'
         - name: mypy
           commands:
             - sem-version python 3.8
             - checkout --use-cache
-            - python -m pip install --upgrade poetry
-            - poetry install
+            - pip install poetry==1.3.2 --no-cache
+            - poetry install --no-root --no-interaction --no-ansi
             - bash -c '! poetry run mypy src/replit | grep database.py'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,6 @@ sys.path.append(os.path.abspath("../src"))
 
 import replit
 
-
 # -- Project information -----------------------------------------------------
 
 project = "replit-py"
@@ -27,7 +26,7 @@ copyright = "2021"
 author = "<a href='https://repl.it/'>Replit</a>"
 
 # The full version, including alpha/beta/rc tags
-release = "3.2.2"
+release = "3.3.0"
 html_theme = "alabaster"
 
 # -- General configuration ---------------------------------------------------
@@ -50,7 +49,6 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "conf.py"]
 
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -65,7 +63,8 @@ html_static_path = ["_static"]
 html_theme_options = {"show_powered_by": False}
 
 html_sidebars = {
-    "index": ["sidebarintro.html", "sourcelink.html", "searchbox.html", "hacks.html"],
+    "index":
+    ["sidebarintro.html", "sourcelink.html", "searchbox.html", "hacks.html"],
     "**": [
         "sidebarintro.html",
         "localtoc.html",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "replit"
-version = "3.2.5"
+version = "3.3.0"
 description = "A library for interacting with features of repl.it"
 authors = ["Repl.it <contact@repl.it>", "mat <pypi@matdoes.dev>", "kennethreitz <me@kennethreitz.org>", "Scoder12 <pypi@scoder12.ml>", "AllAwesome497", ]
 license = "ISC"

--- a/src/replit/database/default_db.py
+++ b/src/replit/database/default_db.py
@@ -13,6 +13,7 @@ def reload_db() -> None:
     Reloads the database. The database token expires every 20h.
     """
     global db
+    print('Reloading database...')
     if path.exists("/tmp/replitdb"):
         with open("/tmp/replitdb", 'r') as file:
             db_url = file.read()
@@ -28,7 +29,8 @@ def reload_db() -> None:
 
 def refresh_db() -> None:
     """Refresh the DB URL every hour"""
-    threading.Timer(3600, reload_db).start()
+    print('Invoking refresh loop')
+    threading.Timer(10, reload_db).start()
 
 
 refresh_db()

--- a/src/replit/database/default_db.py
+++ b/src/replit/database/default_db.py
@@ -24,7 +24,6 @@ def refresh_db() -> None:
     global db
     db_url = get_db_url()
     db.update_db_url(db_url)
-    print('Updated DB URL')
     threading.Timer(3600, refresh_db).start()
 
 

--- a/src/replit/database/default_db.py
+++ b/src/replit/database/default_db.py
@@ -5,34 +5,35 @@ import threading
 
 from .database import Database
 
-db: Optional[Database] = None
 
-db_url: str = environ.get("REPLIT_DB_URL")
-
-
-def reload_db() -> None:
+def get_db_url() -> str:
     """
-    Reloads the database. The database token expires every 20h.
+    Fetches the most up-to-date db url from the Repl environment.
     """
-    global db
-    global db_url
     if path.exists("/tmp/replitdb"):
         with open("/tmp/replitdb", 'r') as file:
             db_url = file.read()
     else:
         db_url = environ.get("REPLIT_DB_URL")
 
-    if db_url:
-        db = Database(db_url)
-    else:
-        # The user will see errors if they try to use the database.
-        db = None
+    return db_url
 
 
 def refresh_db() -> None:
     """Refresh the DB URL every hour"""
-    reload_db()
+    global db
+    db_url = get_db_url()
+    db.update_db_url(db_url)
+    print('Updated DB URL')
     threading.Timer(3600, refresh_db).start()
 
+
+db: Optional[Database]
+db_url = get_db_url()
+if db_url:
+    db = Database(db_url)
+else:
+    # The user will see errors if they try to use the database.
+    db = None
 
 refresh_db()

--- a/src/replit/database/default_db.py
+++ b/src/replit/database/default_db.py
@@ -5,7 +5,9 @@ import threading
 
 from .database import Database
 
-db: Optional[Database]
+db: Optional[Database] = None
+
+db_url: str = environ.get("REPLIT_DB_URL")
 
 
 def reload_db() -> None:
@@ -13,7 +15,7 @@ def reload_db() -> None:
     Reloads the database. The database token expires every 20h.
     """
     global db
-    print('Reloading database...')
+    global db_url
     if path.exists("/tmp/replitdb"):
         with open("/tmp/replitdb", 'r') as file:
             db_url = file.read()
@@ -29,8 +31,8 @@ def reload_db() -> None:
 
 def refresh_db() -> None:
     """Refresh the DB URL every hour"""
-    print('Invoking refresh loop')
-    threading.Timer(10, reload_db).start()
+    reload_db()
+    threading.Timer(3600, refresh_db).start()
 
 
 refresh_db()

--- a/src/replit/database/default_db.py
+++ b/src/replit/database/default_db.py
@@ -1,18 +1,34 @@
 """A module containing the default database."""
-from os import environ
+from os import environ, path
 from typing import Optional
+import threading
 
 from .database import Database
 
 db: Optional[Database]
-if os.path.exists("/tmp/replitdb"):
-    with open(file_path, 'r') as file:
-        db_url = file.read()
-else:
-    db_url = environ.get("REPLIT_DB_URL")
 
-if db_url:
-    db = Database(db_url)
-else:
-    # The user will see errors if they try to use the database.
-    db = None
+
+def reload_db() -> None:
+    """
+    Reloads the database. The database token expires every 20h.
+    """
+    global db
+    if path.exists("/tmp/replitdb"):
+        with open("/tmp/replitdb", 'r') as file:
+            db_url = file.read()
+    else:
+        db_url = environ.get("REPLIT_DB_URL")
+
+    if db_url:
+        db = Database(db_url)
+    else:
+        # The user will see errors if they try to use the database.
+        db = None
+
+
+def refresh_db() -> None:
+    """Refresh the DB URL every hour"""
+    threading.Timer(3600, reload_db).start()
+
+
+refresh_db()

--- a/src/replit/database/default_db.py
+++ b/src/replit/database/default_db.py
@@ -5,7 +5,12 @@ from typing import Optional
 from .database import Database
 
 db: Optional[Database]
-db_url = environ.get("REPLIT_DB_URL")
+if os.path.exists("/tmp/replitdb"):
+    with open(file_path, 'r') as file:
+        db_url = file.read()
+else:
+    db_url = environ.get("REPLIT_DB_URL")
+
 if db_url:
     db = Database(db_url)
 else:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,7 +14,11 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self) -> None:
         """Grab a JWT for all the tests to share."""
-        if "REPLIT_DB_URL" in os.environ:
+        if os.path.exists("/tmp/replitdb"):
+            with open(file_path, 'r') as file:
+                db_url = file.read()
+                self.db = AsyncDatabase(db_url)
+        elif "REPLIT_DB_URL" in os.environ:
             self.db = AsyncDatabase(os.environ["REPLIT_DB_URL"])
         else:
             password = os.environ["PASSWORD"]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,12 +14,15 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self) -> None:
         """Grab a JWT for all the tests to share."""
-        if os.path.exists("/tmp/replitdb"):
-            with open(file_path, 'r') as file:
-                db_url = file.read()
-                self.db = AsyncDatabase(db_url)
-        elif "REPLIT_DB_URL" in os.environ:
+        if "REPLIT_DB_URL" in os.environ:
             self.db = AsyncDatabase(os.environ["REPLIT_DB_URL"])
+        elif "DB_RIDT" in os.environ:
+            password = os.environ["RIDT_PASSWORD"]
+            req = requests.get(
+                "https://database-test-ridt.util.repl.co", auth=("test", password)
+            )
+            url = req.text
+            self.db = AsyncDatabase(url)
         else:
             password = os.environ["PASSWORD"]
             req = requests.get(


### PR DESCRIPTION
# Why

The JWT used for authenticating into the Replit DB is placed on the Repl as an environment variable on boot and lasts for 30h or so. This is fine for shorter lasting Repls, but if we want to have long-running Repls we need a mechanism to refresh the DB token.

# What changed

Let's make it so that we read the DB URL data from a file, which can be refreshed while a program is running. If the file does not exist or we fail to read from it, fall back to the environment variable. We then run this hourly.

# Testing

- Fork [this Repl](https://replit.com/@util/emoji-vote-kv)
- Change the version of the `replit` dependency in `pyproject.toml` to the latest commit in this branch. The resulting `[tool.poetry.dependencies]` section should look something like the following.

```
[tool.poetry.dependencies]
python = ">=3.10.0,<3.11"
numpy = "^1.22.2"
Flask = "^2.2.0"
urllib3 = "^1.26.12"
replit = { git = "https://github.com/replit/replit-py.git", rev = "71466f774ef1c0d737259d249085dc42606424cd" }
```

- Run `poetry update`
- Run the Repl and make sure the application works 
- Deploy the Repl and make sure that it still works. Also check that both the plain Repl and the deployment are using the same database by checking that the values shown on the page match.

