### PR TITLE
[👻] Update the Ghostwriter token

### DIFF
--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -23,10 +23,10 @@ class TestIdentity(unittest.TestCase):
         pubkey = replit.identity.read_public_key_from_env("dev:1", "goval")
         self.assertIsInstance(pubkey, pyseto.versions.v2.V2Public)
 
-    @unittest.skip("todo: investigate how to update this token")
     def test_verify_ghostwriter(self) -> None:
         """Test verify_ghostwriter."""
-        # This token should be valid for 10y.
+        # This token should be valid for 100y.
+        # Generated with `go run ./cmd/goval_keypairgen/ -eternal -sample-token -ghostwriter -gen-prefix dev -gen-id ghostwriter -issuer ghostwriter` in goval.
         replit.identity.verify_ghostwriter(
-            "v2.public.Q2dzSTc4L0htZ1lRbXB1VmNoSUxDTDZDekpvR0VOQ2RsWEk9S1AmYjDdBvVZjmHFgcYVDD57VvJFKbXF9q-fFYQ0XYu12xG8cMV0EK12qFcD3ihtCdqkNoCbNmFpNByDooKSDA.R0FFaUMyZG9iM04wZDNKcGRHVnlFcndDZGpJdWNIVmliR2xqTGxFeVpIcFRWR00wVERCb2RGb3hiRkpNTURWRVVrZE9iMU5WZUVSVVJGcEVaV3R3ZGxJd1ZrNVpiR3h1VFRCc2FGRlhhRzVTTUdSdVUxWnNRbUZIT1VSU01FWk9XVlZHYjFvd1ZrcGhiRnA1VkZkck1XUXlVbGhUYms1b1ZqQXhNVnBXV2tObGJGcHlZVWhPVTJWck5ERmFSelZyWkZVNVJtVkdWbXROUkdneldsY3hjMU5IU2xobFJFcHJVakJzTUZsVVFrdFZSMFpYV25wQ1lWSkdTbHBhUnpGSFpFVXdlR0ZGY0dGa2VqQTVUbXRKWWpaM1NscG9NRGcyYnpRMGIwaEhVRGhCZG13MWNWaHRaMkUyZFd4R1JGcHhObmRSWTFGU2MyRnVjV2hXVEhsamJsQTRXbTFEUVhOV2JWOVplbmQxZUVreGIwaEVZbmQzYmw4d2QxbzRaakp4UTJjdVVqQkdSbUZWVFhsYVJ6bHBUVEEwZDFwRVRrdGpSMUpJVm01c1JGb3hXbkpYYkdoYVRtc3hVbEJVTUE9PQ"  # noqa: E501,B950 # line too long
+            "v2.public.Q2d3SXpwSEZwZ1lRdS9uS2hnSVNEQWlPeE1tbUJoQ1QrOHFHQWhvRWRHVnpkQT09Cupv8UwpdFsrAj8U_lAZXxYaBL3jL-tMHkhpveBEHqNpTGehlN-oWlEYcvyUwQq9JKxvNSblReAdElDxGXrkBQ.R0FFaUMyZG9iM04wZDNKcGRHVnlFcVlDZGpJdWNIVmliR2xqTGxFeVpETlRXRmt4VTBWYWQxb3hiRkprVkdoUVRqSm9ibE5XVGtWUlYyeFFaVVV4ZEdKVlNtOVNSM0ExV1c1V1NGRlhhSFpSTUdSQ1YxZHNUMVl6VGpWVVJ6VkRUVlpzZEdWSVFscGxWRlp6VmtaYWIxbFhWbGhXYlhSVlZteEtUMVJWVFhkTmJVWkhZMGhXYW1KVWJIWmFWVlY0VkVkR1JWVnVWbFppYlhONFdURm9iMVpzYjNsT1dFSmhZa1ZhYlZkSWNGTlViRloxVjIwMWNWZFFRVVUwZDNNdFltaGFaMGxPV2xGRlMwRjFOa3B0V1dVeVRYcHZabXBEYkZwaWJVWjRVbXBzZUhnMGVXMWlkazloTjJOM1ZuZzJZemR0YUhsaFpVaGtlamwyT0c5Rk1XRmxhekZsYlZVNU9XTlJUaTVTTUVaR1lWVk5lVnBIT1dsTk1EUjNXa1JPUzJOSFVraFdibXhFV2pGYWNsZHNhRnBPYXpGU1VGUXc"  # noqa: E501,B950 # line too long
         )


### PR DESCRIPTION
Why
===

The token that was added 10m ago that was supposed to last 10y lasted less than one.


What changed
============

This change updates the token so that it lasts 100y and adds the little commandline snippet to regenerate it in case we need to.

Test plan
=========

```shell
~/replit-py$ poetry run python -m unittest tests/test_identity.py
Warning: error initializing database. Replit DB is not configured.
..
----------------------------------------------------------------------
Ran 2 tests in 0.030s

OK
```

Rollout
=======

- [X] This is fully backward and forward compatible