### PR TITLE
[identity] Allow signing tokens

### DIFF
--- a/src/replit/identity/__init__.py
+++ b/src/replit/identity/__init__.py
@@ -1,4 +1,5 @@
 """Python implementation of Replit identity."""
 
 from .exceptions import *  # noqa: F403,F401
+from .sign import *  # noqa: F403,F401
 from .verify import *  # noqa: F403,F401

--- a/src/replit/identity/sign.py
+++ b/src/replit/identity/sign.py
@@ -1,0 +1,63 @@
+"""This library allows signing identity tokens from Replit."""
+
+import base64
+
+import pyseto
+
+from . import verify
+from ..goval.api import signing_pb2
+
+
+class SigningAuthority:
+    """A class to generate tokens that prove identity.
+
+    This class proves the identity of one repl (your own) against another repl
+    (the audience). Use this to prevent the target repl from spoofing your own
+    identity by forwarding the token.
+    """
+
+    def __init__(
+        self,
+        marshaled_private_key: str,
+        marshaled_identity: str,
+        replid: str,
+        pubkey_source: verify.PubKeySource = verify.read_public_key_from_env,
+    ) -> None:
+        """Creates a new SigningAuthority.
+
+        Args:
+            marshaled_private_key: The private key, in PASERK format.
+            marshaled_identity: The PASETO of the Repl identity.
+            replid: The ID of the source Repl.
+            pubkey_source: The PubKeySource to get the public key.
+        """
+        self.identity = verify.verify_identity_token(
+            marshaled_identity, replid, pubkey_source
+        )
+        self.signing_authority = verify.get_signing_authority(marshaled_identity)
+        self.private_key = pyseto.Key.from_paserk(marshaled_private_key)
+
+    def sign(self, audience: str) -> str:
+        """Generates a new token that can be given to the provided audience.
+
+        This is resistant against forwarding, so that the recipient cannot
+        forward this token to another repl and claim it came directly from you.
+
+        Args:
+            audience: The audience that the token will be signed for.
+
+        Returns:
+            The encoded token in PASETO format.
+        """
+        identity = signing_pb2.GovalReplIdentity()
+        identity.CopyFrom(self.identity)
+        identity.aud = audience
+
+        encoded_identity = identity.SerializeToString()
+        encoded_cert = self.signing_authority.SerializeToString()
+
+        return pyseto.encode(
+            self.private_key,
+            base64.b64encode(encoded_identity),
+            base64.b64encode(encoded_cert),
+        ).decode("utf-8")

--- a/src/replit/identity/verify.py
+++ b/src/replit/identity/verify.py
@@ -55,7 +55,18 @@ def _parse_claims(cert: signing_pb2.GovalCert) -> _MessageClaims:
     return claims
 
 
-def _get_signing_authority(token: str) -> signing_pb2.GovalSigningAuthority:
+def get_signing_authority(token: str) -> signing_pb2.GovalSigningAuthority:
+    """Gets the signing authority from a token.
+
+    Args:
+        token: The token in a PASETO format.
+
+    Returns:
+        The parsed GovalSigningAuthority.
+
+    Raises:
+        VerifyError: If there's any problem verifying the token.
+    """
     # The library does not allow just grabbing the footer to know what key to
     # use, so we need to manually extract that.
     token_parts = token.split(".")
@@ -157,7 +168,7 @@ class Verifier:
         pubkey_source: PubKeySource,
     ) -> Tuple[bytes, Optional[signing_pb2.GovalCert]]:
         """Verifies that the token and its signing chain are valid."""
-        gsa = _get_signing_authority(token)
+        gsa = get_signing_authority(token)
 
         if gsa.key_id != "":
             # If it's signed directly with a root key, grab the pubkey and

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -9,6 +9,17 @@ import replit.identity
 
 PUBLIC_KEY = "on0FkSmEC+ce40V9Vc4QABXSx6TXo+lhp99b6Ka0gro="
 
+# This token should be valid for 100y.
+# Generated with:
+# ```
+# go run ./cmd/goval_keypairgen/ -eternal -sample-token \
+#   -identity -gen-prefix dev -gen-id identity -issuer conman \
+#   -replid=test -shortlived=false
+# ```
+# in goval.
+IDENTITY_PRIVATE_KEY = "k2.secret.6sHU27WoRIaspIOVaShpuZM33ozpfFyI2THfO8fmSX6xiA_Duh4ac5g76Y5bParclsalaOCTaCs6gZowhYivVQ"  # noqa: E501,B950,S106 # line too long
+IDENTITY_TOKEN = "v2.public.Q2dSMFpYTjBJZ1IwWlhOMHDnO17Eg43zucAMSAHnCS4C1wn4QUCCOcr-Pggw5SV1KnbOXq8RcQE5if6pMcbJ6lmRWcdoHq5CV9jqyRrUlwo.R0FFaUJtTnZibTFoYmhLckFuWXlMbkIxWW14cFl5NVJNbVF6VTFkd2VHRnRXbmRrTVd4U1lXMDViRm96YkVKU1ZrNUZVVmRzYTA1VmQzSlRSVlp2VWtaa2RGbFZVa3BSVmtwMlVUQmtRbFpYUmtOYU1qbEdXa1ZrVjJWdFVrUlRWRVpvWld0c01Wa3dhRmRoVjBwSVlrZHdUV0pyTldGWGFrWkRUVEEwZVU5WGVGTk5hbFpSVmpGVk5HUkhTbFpQVm1oc1lXdHdORlJVUW5kaFZrbDZVV3hvYUdKWFVubFVWekZyWlZaUmVVOVZhRnBXVkVaTFZtcENjMlZWTVZkV1ZEQkRUbVpoYkhkMk5EUm9SRkZQTFVKWlJDMURWSEUxYVdJeFQzVlVlamxIWW5WTlFVVnFURFExUVVwclZXNW9kR2hxVFZOVVRtOVZSRVphWDBsaVUyTjFjekoxWW05aVowNU1MV2RRVlRGRmVVOTFUVzlHTGxJd1JrWmhWVXAwVkc1YWFXSlVSbTlaYldSMlVteHdTRlpxU2xCaGExVTU"  # noqa: E501,B950,S106 # line too long
+
 
 class TestIdentity(unittest.TestCase):
     """Tests for replit.identity."""
@@ -23,18 +34,24 @@ class TestIdentity(unittest.TestCase):
         pubkey = replit.identity.read_public_key_from_env("dev:1", "goval")
         self.assertIsInstance(pubkey, pyseto.versions.v2.V2Public)
 
+    def test_signing_authority(self) -> None:
+        """Test SigningAuthority."""
+        gsa = replit.identity.SigningAuthority(
+            marshaled_private_key=IDENTITY_PRIVATE_KEY,
+            marshaled_identity=IDENTITY_TOKEN,
+            replid="test",
+        )
+        signed_token = gsa.sign("audience")
+
+        replit.identity.verify_identity_token(
+            identity_token=signed_token,
+            audience="audience",
+        )
+
     def test_verify_identity_token(self) -> None:
         """Test verify_identity_token."""
-        # This token should be valid for 100y.
-        # Generated with:
-        # ```
-        # go run ./cmd/goval_keypairgen/ -eternal -sample-token \
-        #   -identity -gen-prefix dev -gen-id identity -issuer conman \
-        #   -replid=test -shortlived=false
-        # ```
-        # in goval.
         replit.identity.verify_identity_token(
-            identity_token="v2.public.Q2dSMFpYTjBJZ1IwWlhOMFxmipFrFWTrOkBoOzmSd8l3hYl88GIxsQTq4oueW4d8Lq7mhxYhl3RrZ6Tty24kpkOuIf0b5h582qp98L9iJwI.R0FFaUJtTnZibTFoYmhLbUFuWXlMbkIxWW14cFl5NVJNbVI2VTFkNGJXVnRWbmRrTVd4U1QxaFJNMkp0U2tOVFZYaEVVekZOTUdScVVtcFZNRlpPWVcwd01VMXVaR2hSVjJodVVtdGtibGRWZEVOVFJrcHpXWHBPVW1GVk5WaGpNMnhOWW10SmVGZFhNVFJqUm13MVRsWk9hMDFyV1hoVk1qRnpZVlp3U0dJemFHaGhlbFY1VjFaa2IxVnNaRmxpTTJSaFpWUkZlVlJYY0d0WGJFcDBWMjVLYUZaclZYcGFWbVJyWlVkU1JtUkVXbXRTYkZwV1ZGUktWazVLZVdKaGJsWmlOeTFRTUZsRWJIRnlibkZCV1RaSGMwRTFZbU5rUWtaUmVIRkJNMnRSWkd0NFozSXdYeTFrUVZSUGFtRk9PRGhFUkZVMldVZFJlazlwTkY5WVoyaGlTbWM1WVRodE1GcFlNRGhwTm14QldTNVNNRVpHWVZWS2RGUnVXbWxpVkVadldXMWtkbEpzY0VoV2FrcFFZV3RWT1E9PQ",  # noqa: E501,B950,S106 # line too long
+            identity_token=IDENTITY_TOKEN,
             audience="test",
         )
 


### PR DESCRIPTION
Why
===

We didn't implement signing tokens before. But it's time to allow that.

What changed
============

This change allows signing tokens and then verifying them.

Test plan
=========

```shell
PASSWORD=foo poetry run python -m unittest tests/test_identity.py 
```

Rollout
=======

- [X] This is fully backward and forward compatible