### PR TITLE
[FIX] Prevent keys from starting with slashes

### DIFF
--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -207,7 +207,7 @@ class AsyncDatabase:
         Args:
             values (Dict[str, str]): The key-value pairs to set.
         """
-        async with self.client.post(self.db_url, data=values) as response:
+        async with self.client.post(self.db_url, data={keyStrip(k), v for k,v in values.items()}) as response:
             response.raise_for_status()
 
     async def delete(self, key: str) -> None:
@@ -641,7 +641,7 @@ class Database(abc.MutableMapping):
         Args:
             values (Dict[str, str]): The key-value pairs to set.
         """
-        r = self.sess.post(self.db_url, data=values)
+        r = self.sess.post(self.db_url, data={keyStrip(k), v for k,v in values.items()})
         r.raise_for_status()
 
     def __delitem__(self, key: str) -> None:

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -207,7 +207,8 @@ class AsyncDatabase:
         Args:
             values (Dict[str, str]): The key-value pairs to set.
         """
-        async with self.client.post(self.db_url, data={keyStrip(k): v for k,v in values.items()}) as response:
+        values = {keyStrip(k): v for k, v in values.items()}
+        async with self.client.post(self.db_url, data=values) as response:
             response.raise_for_status()
 
     async def delete(self, key: str) -> None:
@@ -641,7 +642,8 @@ class Database(abc.MutableMapping):
         Args:
             values (Dict[str, str]): The key-value pairs to set.
         """
-        r = self.sess.post(self.db_url, data={keyStrip(k): v for k,v in values.items()})
+        values = {keyStrip(k): v for k,v in values.items()}
+        r = self.sess.post(self.db_url, data=values)
         r.raise_for_status()
 
     def __delitem__(self, key: str) -> None:

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -61,7 +61,7 @@ def dumps(val: Any) -> str:
 _dumps = dumps
 
 
-def keyStrip(key: str) -> str:
+def _sanitize_key(key: str) -> str:
     """Strip slashes from the beginning of keys.
 
     Args:
@@ -207,7 +207,7 @@ class AsyncDatabase:
         Args:
             values (Dict[str, str]): The key-value pairs to set.
         """
-        values = {keyStrip(k): v for k, v in values.items()}
+        values = {_sanitize_key(k): v for k, v in values.items()}
         async with self.client.post(self.db_url, data=values) as response:
             response.raise_for_status()
 
@@ -642,7 +642,7 @@ class Database(abc.MutableMapping):
         Args:
             values (Dict[str, str]): The key-value pairs to set.
         """
-        values = {keyStrip(k): v for k, v in values.items()}
+        values = {_sanitize_key(k): v for k, v in values.items()}
         r = self.sess.post(self.db_url, data=values)
         r.raise_for_status()
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -207,7 +207,7 @@ class AsyncDatabase:
         Args:
             values (Dict[str, str]): The key-value pairs to set.
         """
-        async with self.client.post(self.db_url, data={keyStrip(k), v for k,v in values.items()}) as response:
+        async with self.client.post(self.db_url, data={keyStrip(k): v for k,v in values.items()}) as response:
             response.raise_for_status()
 
     async def delete(self, key: str) -> None:
@@ -641,7 +641,7 @@ class Database(abc.MutableMapping):
         Args:
             values (Dict[str, str]): The key-value pairs to set.
         """
-        r = self.sess.post(self.db_url, data={keyStrip(k), v for k,v in values.items()})
+        r = self.sess.post(self.db_url, data={keyStrip(k): v for k,v in values.items()})
         r.raise_for_status()
 
     def __delitem__(self, key: str) -> None:

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -58,6 +58,9 @@ def dumps(val: Any) -> str:
     return json.dumps(val, separators=(",", ":"), cls=DBJSONEncoder)
 
 
+_dumps = dumps
+
+
 def keyStrip(key: str) -> str:
     """Strip slashes from the beginning of keys.
 
@@ -68,9 +71,6 @@ def keyStrip(key: str) -> str:
         str: The stripped key
     """
     return key.lstrip("/")
-
-
-_dumps = dumps
 
 
 class AsyncDatabase:

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -72,6 +72,7 @@ def keyStrip(key: str) -> str:
 
 _dumps = dumps
 
+
 class AsyncDatabase:
     """Async interface for Replit Database.
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -57,6 +57,7 @@ def dumps(val: Any) -> str:
     """
     return json.dumps(val, separators=(",", ":"), cls=DBJSONEncoder)
 
+
 def keyStrip(key: str) -> str:
     """Strip slashes from the beginning of keys.
 
@@ -67,6 +68,7 @@ def keyStrip(key: str) -> str:
         str: The stripped key
     """
     return key.lstrip("/")
+
 
 _dumps = dumps
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -642,7 +642,7 @@ class Database(abc.MutableMapping):
         Args:
             values (Dict[str, str]): The key-value pairs to set.
         """
-        values = {keyStrip(k): v for k,v in values.items()}
+        values = {keyStrip(k): v for k, v in values.items()}
         r = self.sess.post(self.db_url, data=values)
         r.raise_for_status()
 

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -181,7 +181,7 @@ class AsyncDatabase:
             key (str): The key to set
             value (Any): The value to set it to. Must be JSON-serializable.
         """
-        await self.set_raw(keyStrip(key), _dumps(value))
+        await self.set_raw(key, _dumps(value))
 
     async def set_raw(self, key: str, value: str) -> None:
         """Set a key in the database to value.
@@ -190,7 +190,7 @@ class AsyncDatabase:
             key (str): The key to set
             value (str): The value to set it to
         """
-        await self.set_bulk_raw({keyStrip(key): value})
+        await self.set_bulk_raw({key: value})
 
     async def set_bulk(self, values: Dict[str, Any]) -> None:
         """Set multiple values in the database, JSON encoding them.
@@ -199,7 +199,7 @@ class AsyncDatabase:
             values (Dict[str, Any]): A dictionary of values to put into the dictionary.
                 Values must be JSON serializeable.
         """
-        await self.set_bulk_raw({keyStrip(k): _dumps(v) for k, v in values.items()})
+        await self.set_bulk_raw({k: _dumps(v) for k, v in values.items()})
 
     async def set_bulk_raw(self, values: Dict[str, str]) -> None:
         """Set multiple values in the database.
@@ -607,7 +607,7 @@ class Database(abc.MutableMapping):
             key (str): The key to set
             value (Any): The value to set it to. Must be JSON-serializable.
         """
-        self.set(keyStrip(key), value)
+        self.set(key, value)
 
     def set(self, key: str, value: Any) -> None:
         """Set a key in the database to value, JSON encoding it.
@@ -616,7 +616,7 @@ class Database(abc.MutableMapping):
             key (str): The key to set
             value (Any): The value to set.
         """
-        self.set_raw(keyStrip(key), _dumps(value))
+        self.set_raw(key, _dumps(value))
 
     def set_raw(self, key: str, value: str) -> None:
         """Set a key in the database to value.
@@ -625,7 +625,7 @@ class Database(abc.MutableMapping):
             key (str): The key to set
             value (str): The value to set.
         """
-        self.set_bulk_raw({keyStrip(key): value})
+        self.set_bulk_raw({key: value})
 
     def set_bulk(self, values: Dict[str, Any]) -> None:
         """Set multiple values in the database, JSON encoding them.
@@ -634,7 +634,7 @@ class Database(abc.MutableMapping):
             values (Dict[str, Any]): A dictionary of values to put into the dictionary.
                 Values must be JSON serializeable.
         """
-        self.set_bulk_raw({keyStrip(k): _dumps(v) for k, v in values.items()})
+        self.set_bulk_raw({k: _dumps(v) for k, v in values.items()})
 
     def set_bulk_raw(self, values: Dict[str, str]) -> None:
         """Set multiple values in the database.

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -57,9 +57,18 @@ def dumps(val: Any) -> str:
     """
     return json.dumps(val, separators=(",", ":"), cls=DBJSONEncoder)
 
+def keyStrip(key: str) -> str:
+    """Strip slashes from the beginning of keys.
+
+    Args:
+        key (str): The key to strip
+
+    Returns:
+        str: The stripped key
+    """
+    return key.lstrip("/")
 
 _dumps = dumps
-
 
 class AsyncDatabase:
     """Async interface for Replit Database.
@@ -169,7 +178,7 @@ class AsyncDatabase:
             key (str): The key to set
             value (Any): The value to set it to. Must be JSON-serializable.
         """
-        await self.set_raw(key, _dumps(value))
+        await self.set_raw(keyStrip(key), _dumps(value))
 
     async def set_raw(self, key: str, value: str) -> None:
         """Set a key in the database to value.
@@ -178,7 +187,7 @@ class AsyncDatabase:
             key (str): The key to set
             value (str): The value to set it to
         """
-        await self.set_bulk_raw({key: value})
+        await self.set_bulk_raw({keyStrip(key): value})
 
     async def set_bulk(self, values: Dict[str, Any]) -> None:
         """Set multiple values in the database, JSON encoding them.
@@ -187,7 +196,7 @@ class AsyncDatabase:
             values (Dict[str, Any]): A dictionary of values to put into the dictionary.
                 Values must be JSON serializeable.
         """
-        await self.set_bulk_raw({k: _dumps(v) for k, v in values.items()})
+        await self.set_bulk_raw({keyStrip(k): _dumps(v) for k, v in values.items()})
 
     async def set_bulk_raw(self, values: Dict[str, str]) -> None:
         """Set multiple values in the database.
@@ -594,7 +603,7 @@ class Database(abc.MutableMapping):
             key (str): The key to set
             value (Any): The value to set it to. Must be JSON-serializable.
         """
-        self.set(key, value)
+        self.set(keyStrip(key), value)
 
     def set(self, key: str, value: Any) -> None:
         """Set a key in the database to value, JSON encoding it.
@@ -603,7 +612,7 @@ class Database(abc.MutableMapping):
             key (str): The key to set
             value (Any): The value to set.
         """
-        self.set_raw(key, _dumps(value))
+        self.set_raw(keyStrip(key), _dumps(value))
 
     def set_raw(self, key: str, value: str) -> None:
         """Set a key in the database to value.
@@ -612,7 +621,7 @@ class Database(abc.MutableMapping):
             key (str): The key to set
             value (str): The value to set.
         """
-        self.set_bulk_raw({key: value})
+        self.set_bulk_raw({keyStrip(key): value})
 
     def set_bulk(self, values: Dict[str, Any]) -> None:
         """Set multiple values in the database, JSON encoding them.
@@ -621,7 +630,7 @@ class Database(abc.MutableMapping):
             values (Dict[str, Any]): A dictionary of values to put into the dictionary.
                 Values must be JSON serializeable.
         """
-        self.set_bulk_raw({k: _dumps(v) for k, v in values.items()})
+        self.set_bulk_raw({keyStrip(k): _dumps(v) for k, v in values.items()})
 
     def set_bulk_raw(self, values: Dict[str, str]) -> None:
         """Set multiple values in the database.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -127,7 +127,7 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
 
     async def test_slash_keys(self) -> None:
         """Test that slash keys work."""
-        k = "/slash-test"
+        k = "/key"
         # set
         await self.db.set(k,"val1")
         self.assertEqual(await self.db.get(k), "val1")
@@ -289,7 +289,7 @@ class TestDatabase(unittest.TestCase):
 
     def test_slash_keys(self) -> None:
         """Test that slash keys work."""
-        k = "/slash-test"
+        k = "/key"
         # set
         self.db.set(k,"val1")
         val = self.db[k]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -125,6 +125,33 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await self.db.get_raw("bulk1"), "val1")
         self.assertEqual(await self.db.get_raw("bulk2"), "val2")
 
+    async def test_slash_keys(self) -> None:
+        """Test that slash keys work."""
+        k = "/slash-test"
+        # set
+        await self.db.set(k,"val1")
+        self.assertEqual(await self.db.get(k), "val1")
+        await self.db.delete(k)
+        with self.assertRaises(KeyError):
+            await self.db.get(k)
+        # set_raw
+        await self.db.set_raw(k,"val1")
+        self.assertEqual(await self.db.get(k), "val1")
+        await self.db.delete(k)
+        with self.assertRaises(KeyError):
+            await self.db.get(k)
+        # set_bulk
+        await self.db.set_bulk({k: "val1"})
+        self.assertEqual(await self.db.get(k), "val1")
+        await self.db.delete(k)
+        with self.assertRaises(KeyError):
+            await self.db.get(k)
+        # set_bulk_raw
+        await self.db.set_bulk_raw({k: "val1"})
+        self.assertEqual(await self.db.get(k), "val1")
+        await self.db.delete(k)
+        with self.assertRaises(KeyError):
+            await self.db.get(k)
 
 class TestDatabase(unittest.TestCase):
     """Tests for replit.database.Database."""
@@ -259,3 +286,31 @@ class TestDatabase(unittest.TestCase):
         self.db.set_bulk_raw({"bulk1": "val1", "bulk2": "val2"})
         self.assertEqual(self.db.get_raw("bulk1"), "val1")
         self.assertEqual(self.db.get_raw("bulk2"), "val2")
+
+    def test_slash_keys(self) -> None:
+        """Test that slash keys work."""
+        k = "/slash-test"
+        # set
+        self.db.set(k,"val1")
+        self.assertEqual(self.db.get(k), "val1")
+        self.db.delete(k)
+        with self.assertRaises(KeyError):
+            self.db.get(k)
+        # set_raw
+        self.db.set_raw(k,"val1")
+        self.assertEqual(self.db.get(k), "val1")
+        self.db.delete(k)
+        with self.assertRaises(KeyError):
+            self.db.get(k)
+        # set_bulk
+        self.db.set_bulk({k: "val1"})
+        self.assertEqual(self.db.get(k), "val1")
+        self.db.delete(k)
+        with self.assertRaises(KeyError):
+            self.db.get(k)
+        # set_bulk_raw
+        self.db.set_bulk_raw({k: "val1"})
+        self.assertEqual(self.db.get(k), "val1")
+        self.db.delete(k)
+        with self.assertRaises(KeyError):
+            self.db.get(k)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -292,25 +292,25 @@ class TestDatabase(unittest.TestCase):
         k = "/slash-test"
         # set
         self.db.set(k,"val1")
-        self.assertEqual(self.db.get(k), "val1")
+        self.assertEqual(self.db[k], "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
             self.db[k]
         # set_raw
         self.db.set_raw(k,"val1")
-        self.assertEqual(self.db.get(k), "val1")
+        self.assertEqual(self.db[k], "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
             self.db[k]
         # set_bulk
         self.db.set_bulk({k: "val1"})
-        self.assertEqual(self.db.get(k), "val1")
+        self.assertEqual(self.db[k], "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
             self.db[k]
         # set_bulk_raw
         self.db.set_bulk_raw({k: "val1"})
-        self.assertEqual(self.db.get(k), "val1")
+        self.assertEqual(self.db[k], "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
             self.db[k]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -295,22 +295,22 @@ class TestDatabase(unittest.TestCase):
         self.assertEqual(self.db.get(k), "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
-            self.db.get(k)
+            self.db[k]
         # set_raw
         self.db.set_raw(k,"val1")
         self.assertEqual(self.db.get(k), "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
-            self.db.get(k)
+            self.db[k]
         # set_bulk
         self.db.set_bulk({k: "val1"})
         self.assertEqual(self.db.get(k), "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
-            self.db.get(k)
+            self.db[k]
         # set_bulk_raw
         self.db.set_bulk_raw({k: "val1"})
         self.assertEqual(self.db.get(k), "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
-            self.db.get(k)
+            self.db[k]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -136,7 +136,7 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
             await self.db.get(k)
         # set_raw
         await self.db.set_raw(k,"val1")
-        self.assertEqual(await self.db.get(k), "val1")
+        self.assertEqual(await self.db.get_raw(k), "val1")
         await self.db.delete(k)
         with self.assertRaises(KeyError):
             await self.db.get(k)
@@ -148,7 +148,7 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
             await self.db.get(k)
         # set_bulk_raw
         await self.db.set_bulk_raw({k: "val1"})
-        self.assertEqual(await self.db.get(k), "val1")
+        self.assertEqual(await self.db.get_raw(k), "val1")
         await self.db.delete(k)
         with self.assertRaises(KeyError):
             await self.db.get(k)
@@ -292,32 +292,25 @@ class TestDatabase(unittest.TestCase):
         k = "/key"
         # set
         self.db.set(k,"val1")
-        val = self.db[k]
-        self.assertEqual(val, "val1")
+        self.assertEqual(self.db[k], "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
-            val = self.db[k]
+            self.db[k]
         # set_raw
-        del val
         self.db.set_raw(k,"val1")
-        val = self.db[k]
-        self.assertEqual(val, "val1")
+        self.assertEqual(self.db.get_raw(k), "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
-            val = self.db[k]
+            self.db[k]
         # set_bulk
-        del val
         self.db.set_bulk({k: "val1"})
-        val = self.db[k]
-        self.assertEqual(val, "val1")
+        self.assertEqual(self.db.get(k), "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
             self.db[k]
         # set_bulk_raw
-        del val
         self.db.set_bulk_raw({k: "val1"})
-        val = self.db[k]
-        self.assertEqual(val, "val1")
+        self.assertEqual(self.db.get_raw(k), "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
             self.db[k]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -293,24 +293,24 @@ class TestDatabase(unittest.TestCase):
         # set
         self.db.set(k,"val1")
         self.assertEqual(self.db.get(k), "val1")
-        self.db.delete(k)
+        del self.db[k]
         with self.assertRaises(KeyError):
             self.db.get(k)
         # set_raw
         self.db.set_raw(k,"val1")
         self.assertEqual(self.db.get(k), "val1")
-        self.db.delete(k)
+        del self.db[k]
         with self.assertRaises(KeyError):
             self.db.get(k)
         # set_bulk
         self.db.set_bulk({k: "val1"})
         self.assertEqual(self.db.get(k), "val1")
-        self.db.delete(k)
+        del self.db[k]
         with self.assertRaises(KeyError):
             self.db.get(k)
         # set_bulk_raw
         self.db.set_bulk_raw({k: "val1"})
         self.assertEqual(self.db.get(k), "val1")
-        self.db.delete(k)
+        del self.db[k]
         with self.assertRaises(KeyError):
             self.db.get(k)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -292,25 +292,32 @@ class TestDatabase(unittest.TestCase):
         k = "/slash-test"
         # set
         self.db.set(k,"val1")
-        self.assertEqual(self.db[k], "val1")
+        val = self.db[k]
+        self.assertEqual(val, "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
-            self.db[k]
+            val = self.db[k]
         # set_raw
+        del val
         self.db.set_raw(k,"val1")
-        self.assertEqual(self.db[k], "val1")
+        val = self.db[k]
+        self.assertEqual(val, "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
-            self.db[k]
+            val = self.db[k]
         # set_bulk
+        del val
         self.db.set_bulk({k: "val1"})
-        self.assertEqual(self.db[k], "val1")
+        val = self.db[k]
+        self.assertEqual(val, "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
             self.db[k]
         # set_bulk_raw
+        del val
         self.db.set_bulk_raw({k: "val1"})
-        self.assertEqual(self.db[k], "val1")
+        val = self.db[k]
+        self.assertEqual(val, "val1")
         del self.db[k]
         with self.assertRaises(KeyError):
             self.db[k]


### PR DESCRIPTION
If a key starts with a slash, then it becomes undeletable and prevents database purges from working properly as well. This prevents that from occuring by stripping slashes from the left of the key name.

Why
===

At least two separate occurrences where users have accidentally set a key that starts with a slash, and therefore can no longer remove the key or cleared their database.

What changed
============

Changed all references to `key` or `k` when setting a key-value pair to `keyStrip(key)` and `keyStrip(k)` respectively.

Test plan
=========

Attempted to set keys starting with slashes, then subsequently remove them and/or purge the database.

Rollout
=======

Prevents keys from being set with a slash in the future, which was is less breaking than the existing behavior (which is to not process the keys at all)

- [x] This is fully backward and forward compatible
