### PR TITLE
added support for `auth`, plus changed `info` to `repl_info`.

### DIFF
--- a/src/replit/__init__.py
+++ b/src/replit/__init__.py
@@ -12,9 +12,10 @@ from .database import (
     start_database_proxy,
 )
 from .info import ReplInfo
+from .auth import get_user_info
 
-info = ReplInfo()
-
+repl_info = ReplInfo()
+user_info = get_user_info()
 
 # Backwards compatibility.
 def clear() -> None:


### PR DESCRIPTION
Why
===

Once again, I had to do this for my other PR's (please I know :sob:, so many PRs when I could've did them in one. But, I messed up so and I had to do this.).


- [x] This is fully backward and forward compatible
