### PR TITLE
Support Flask 2.3

### DIFF
--- a/examples/web/authenticated.py
+++ b/examples/web/authenticated.py
@@ -20,4 +20,4 @@ def test():
 
 
 if __name__ == "__main__":
-    web.run_app(app)
+    web.run(app)

--- a/examples/web/manual_auth.py
+++ b/examples/web/manual_auth.py
@@ -17,4 +17,4 @@ def index():
 
 
 if __name__ == "__main__":
-    web.run_app(app)
+    web.run(app)

--- a/examples/web/needs_params.py
+++ b/examples/web/needs_params.py
@@ -45,4 +45,4 @@ def query(q):
 
 
 if __name__ == "__main__":
-    web.run_app(app)
+    web.run(app)

--- a/examples/web/ratelimit.py
+++ b/examples/web/ratelimit.py
@@ -19,4 +19,4 @@ def index():
 
 
 if __name__ == "__main__":
-    web.run_app(app)
+    web.run(app)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ documentation = "https://replit-py.readthedocs.org/"
 [tool.poetry.dependencies]
 python = "^3.9"
 typing_extensions = "^4"
-Flask = ">=2.0,<2.3"
+Flask = "^2.0.0"
 Werkzeug = "^2.0.0"
 aiohttp = "^3.6.2"
 requests = "^2.25.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ documentation = "https://replit-py.readthedocs.org/"
 [tool.poetry.dependencies]
 python = "^3.9"
 typing_extensions = "^4"
-Flask = "^2.0.0"
+Flask = ">=2.0,<2.3"
 Werkzeug = "^2.0.0"
 aiohttp = "^3.6.2"
 requests = "^2.25.1"

--- a/src/replit/web/app.py
+++ b/src/replit/web/app.py
@@ -59,7 +59,9 @@ def run(
 ) -> None:
     """A simple wrapper around app.run() with replit compatible defaults."""
     # don't clobber user
-    if change_encoder and app.json_encoder is flask.json.JSONEncoder:
+    if change_encoder and getattr(app, "json_encoder", None) is getattr(
+        flask.json, "json_encoder", None
+    ):
         app.json_encoder = DBJSONEncoder
     app.run(host=host, port=port, **kwargs)
 

--- a/src/replit/web/utils.py
+++ b/src/replit/web/utils.py
@@ -179,7 +179,7 @@ def per_user_ratelimit(
     get_ratelimited_res: Callable[[float], str] = (
         lambda left: f"Too many requests, wait {left} sec"
     ),
-) -> Callable[[Callable], flask.Response]:
+) -> Callable[[Callable], Callable[[Callable], flask.Response]]:
     """Require sign in and limit the amount of requests each signed in user can perform.
 
     This decorator also calls needs_signin for you and passes the login_res kwarg
@@ -200,7 +200,7 @@ def per_user_ratelimit(
     last_reset = time.time()
     num_requests = {}
 
-    def decorator(func: Callable) -> flask.Response:
+    def decorator(func: Callable) -> Callable[..., flask.Response]:
         # Checks for signin first, before checking ratelimit
         @authenticated(login_res=login_res)
         @wraps(func)


### PR DESCRIPTION
next step should be to support Flask 3.0 by supporting Werkzeug 3.0. I have yet to test that

Why
===

prevent errors due to deprecated features (as seen in https://github.com/replit/replit-py/issues/188 in the part *after* Flask was downgraded as `poetry` wanted)

What changed
============

Support 2.3 by accounting for the deprecation of `json_encoder`

Test plan
=========
```bash
poetry update
```
Rollout
=======

- [x] This is fully backward and forward compatible
