### PR TITLE
Fully automatic release versioning

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: 'v$RESOLVED_VERSION 🌈'
+name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,14 +14,31 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade poetry
+
+    - name: Set release version
+      run: |
+        tag="${GITHUB_REF_NAME}"
+        version="${tag#v}"  # Strip leading v
+
+        # Bump poetry tag
+        poetry version "$version"
+
+        # Bump docs tag
+        sed -i'' 's/^release = "[^"]*"/release = "'"$version"'"/' docs/conf.py
+        # Bump docs copyright
+        year="$(date +%Y)"
+        sed -i'' 's/^copyright = "[^"]*"/copyright = "Replit, '"$year"'"/' docs/conf.py
+
     - name: Build and publish
       run: |
         poetry build

--- a/RELEASING
+++ b/RELEASING
@@ -1,6 +1,0 @@
-Update version marker in:
-
-  - ./pyproject.toml
-  - ./docs/_sphinx/conf.py
-
-$ poetry publish --build

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,8 @@
+Cutting new releases is fully managed by GitHub Actions.
+Version numbers do not need to be set in files prior to releasing, as they are incorporated on the fly.
+
+1. Navigate to https://github.com/replit/replit-py/releases
+1. Find the latest `Draft` release, click `Edit`
+1. Verify that the draft looks like what you'd expect
+1. Scroll to the bottom and click `Publish`
+1. Navigate to [`Upload Python Package`](https://github.com/replit/replit-py/actions/workflows/python-publish.yml) and watch your release

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ copyright = "Replit, 2023"
 author = "<a href='https://repl.it/'>Replit</a>"
 
 # The full version, including alpha/beta/rc tags
-release = "3.3.0"
+release = "3.5.0"
 html_theme = "alabaster"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ copyright = "Replit, 2023"
 author = "<a href='https://repl.it/'>Replit</a>"
 
 # The full version, including alpha/beta/rc tags
-release = "3.5.0"
+release = "0.0.0"  # Set via GitHub Actions
 html_theme = "alabaster"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ import replit
 # -- Project information -----------------------------------------------------
 
 project = "replit-py"
-copyright = "2021"
+copyright = "Replit, 2023"
 author = "<a href='https://repl.it/'>Replit</a>"
 
 # The full version, including alpha/beta/rc tags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "replit"
-version = "3.5.0"
+version = "0.0.0"  # Set by GitHub Actions
 description = "A library for interacting with features of repl.it"
 authors = ["Repl.it <contact@repl.it>", "mat <pypi@matdoes.dev>", "kennethreitz <me@kennethreitz.org>", "Scoder12 <pypi@scoder12.ml>", "AllAwesome497", ]
 license = "ISC"


### PR DESCRIPTION
Why
===

Removing footguns and making releases less cumbersome overall.

What changed
============

- Moving ownership of version-number-setting into GHA
- Bumping copyright

Test plan
=========

- Cutting the same version as was just released should kick the tires without breaking anything.

Rollout
=======

- [x] This is fully backward and forward compatible
