### PR TITLE
Close session to fix CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: replit-py
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 blocks:
   - name: Lint and test
     run:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,7 +7,7 @@ agent:
 blocks:
   - name: Lint and test
     run:
-      when: "change_in('/src')"
+      when: "change_in(['/src', '/pyproject.toml', '/tests'])"
     task:
       secrets:
         - name: replit-database

--- a/poetry.lock
+++ b/poetry.lock
@@ -1845,6 +1845,20 @@ files = [
 ]
 
 [[package]]
+name = "types-requests"
+version = "2.31.0.10"
+description = "Typing stubs for requests"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "types-requests-2.31.0.10.tar.gz", hash = "sha256:dc5852a76f1eaf60eafa81a2e50aefa3d1f015c34cf0cba130930866b1b22a92"},
+    {file = "types_requests-2.31.0.10-py3-none-any.whl", hash = "sha256:b32b9a86beffa876c0c3ac99a4cd3b8b51e973fb8e3bd4e0a6bb32c7efad80fc"},
+]
+
+[package.dependencies]
+urllib3 = ">=2"
+
+[[package]]
 name = "typing-extensions"
 version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -2009,4 +2023,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "2e8b5285c7a72eb12236ac7139486cb8653d7678f5e06c464e1c5fcbf5abb0f6"
+content-hash = "0f5735e248b6911612b4e92420eee86f8a9eb60da3c0a62b9d5ea988b3c975d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ flake8-annotations = ">=2.3.0"
 flake8-docstrings = ">=1.5.0"
 mypy = ">=1.5.0"
 coverage = ">=5.2.1"
+types-requests = "^2.31.0.10"
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = ">=7.0.1"

--- a/src/replit/__main__.py
+++ b/src/replit/__main__.py
@@ -36,13 +36,19 @@ def cli() -> None:
 @click.argument("prefix")
 def find_matches(prefix: str) -> None:
     """List all keys that match the given prefix."""
+    if database is None:
+        click.echo(
+            failure("Database connection not available. Ensure REPLIT_DB_URL is set!")
+        )
+        return
+
     matches = list(database.prefix(prefix))
 
     if matches:
-        click.echo(success(f"Matches found for '{prefix}':\n"))
+        click.echo(success(f"Matches found for {prefix!r}:\n"))
         click.echo("\n".join(matches))
     else:
-        click.echo(failure(f"No matches found for '{prefix}'"))
+        click.echo(failure(f"No matches found for {prefix!r}"))
 
 
 @cli.command(name="set")
@@ -51,7 +57,7 @@ def find_matches(prefix: str) -> None:
 def set_value(key: str, val: str) -> None:
     """Add a given key-value pair to the DB."""
     database[key] = val
-    click.echo(success(f"DB[{key}] was successfully set to '{val}'"))
+    click.echo(success(f"DB[{key!r}] was successfully set to {val!r}"))
 
 
 @cli.command(name="del")
@@ -61,10 +67,10 @@ def del_value(key: str) -> None:
     try:
         del database[key]
     except KeyError:
-        click.echo(failure(f"The key '{key}' was not found in the DB."))
+        click.echo(failure(f"The key {key!r} was not found in the DB."))
     else:
         del database[key]
-        click.echo(success(f"db['{key}'] was successfully deleted."))
+        click.echo(success(f"db[{key!r}] was successfully deleted."))
 
 
 @cli.command(name="nuke")
@@ -98,7 +104,7 @@ def list_all(file_path: str) -> None:
 
         json.dump(binds, f)
 
-        click.echo(success(f"Output successfully dumped to '{file_path}'"))
+        click.echo(success(f"Output successfully dumped to {file_path!r}"))
 
 
 if __name__ == "__main__":

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -3,7 +3,6 @@
 from collections import abc
 import json
 from typing import (
-    AbstractSet,
     Any,
     Callable,
     Dict,
@@ -597,7 +596,7 @@ class Database(abc.MutableMapping):
         else:
             return tuple(urllib.parse.unquote(k) for k in r.text.split("\n"))
 
-    def keys(self) -> AbstractSet[str]:
+    def keys(self) -> abc.KeysView[str]:
         """Returns all of the keys in the database.
 
         Returns:
@@ -611,7 +610,7 @@ class Database(abc.MutableMapping):
         #  type db.keys() in an interactive prompt.
 
         # TODO: Return a set from prefix since keys are guaranteed unique
-        return set(self.prefix(""))
+        return abc.KeysView(self)
 
     def dumps(self, val: Any) -> str:
         """JSON encodes a value that can be a special DB object."""

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -13,7 +13,7 @@ from typing import (
     Tuple,
     Union,
 )
-import urllib
+import urllib.parse
 
 import aiohttp
 from aiohttp_retry import ExponentialRetry, RetryClient  # type: ignore

--- a/src/replit/database/database.py
+++ b/src/replit/database/database.py
@@ -622,7 +622,7 @@ class Database(abc.MutableMapping):
         Returns:
             A string representation of the database object.
         """
-        return f"<{self.__class__.__name__}(db_url={self.db_url!r})>"
+        return f"<{self.__class__.__name__}(db_url=...)>"
 
     def close(self) -> None:
         """Closes the database client connection."""

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -39,6 +39,7 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
         """Nuke whatever the test added."""
         for k in await self.db.keys():
             await self.db.delete(k)
+        await self.db.sess.close()
 
     async def test_get_set_delete(self) -> None:
         """Test that we can get, set, and delete a key."""


### PR DESCRIPTION
Why
===

CI is busted due to `aiohttp` socket being leaked between subsequent unittest runs

What changed
============

- Close the session
- Bump away from legacy Semaphore runner
- Add more file paths to semaphore file tracker so we actually run CI on version bump PRs.

Test plan
=========

- Ran unittest on python 3.8 and 3.11

Rollout
=======

- [x] This is fully backward and forward compatible
