### PR TITLE
chore: relax flask dependency constraint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 select = ANN,B,B9,BLK,C,D,DAR,E,F,I,S,W
-ignore = E203,W503,ANN101,ANN102,S322,ANN206,S201,D105,D107,ANN401
+ignore = E203,E501,W503,ANN101,ANN102,S322,ANN206,S201,D105,D107,ANN401
 per-file-ignores =
     src/replit/__init__.py:F401
     src/replit/web/__init__.py:F401

--- a/poetry.lock
+++ b/poetry.lock
@@ -2023,4 +2023,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "0f5735e248b6911612b4e92420eee86f8a9eb60da3c0a62b9d5ea988b3c975d2"
+content-hash = "e548e20dcedb9bea20db49de2fd3e90689bf877344c4dcb226a7b0a9b15a186f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ documentation = "https://replit-py.readthedocs.org/"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 typing_extensions = "^4"
-Flask = "^2.0.0"
+Flask = ">=2.0.0"
 Werkzeug = ">=2,<4"
 aiohttp = "^3.6.2"
 requests = "^2.25.1"

--- a/src/replit/info.py
+++ b/src/replit/info.py
@@ -2,6 +2,8 @@
 import os
 from typing import Optional
 
+from typing_extensions import deprecated
+
 
 class ReplInfo:
     """Represents info about the current repl."""
@@ -33,6 +35,9 @@ class ReplInfo:
         return os.getenv("REPL_LANGUAGE")
 
     @property
+    @deprecated(
+        "Deprecated, please see https://blog.replit.com/hosting-changes for more details"
+    )
     def id_co_url(self) -> Optional[str]:
         """The hosted URL of the repl in the form https://<id>.id.repl.co.
 
@@ -48,6 +53,9 @@ class ReplInfo:
         return f"https://{repl_id}.id.repl.co"
 
     @property
+    @deprecated(
+        "Deprecated, please see https://blog.replit.com/hosting-changes for more details"
+    )
     def co_url(self) -> Optional[str]:
         """The readable, hosted repl.co URL for this repl.
 

--- a/src/replit/web/utils.py
+++ b/src/replit/web/utils.py
@@ -11,7 +11,7 @@ from .app import ReplitAuthContext
 
 authentication_snippet = (
     '<script authed="location.reload()" '
-    'src="https://auth.turbio.repl.co/script.js"></script>'
+    'src="https://replit.com/public/js/repl-auth.js"></script>'
 )
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -19,14 +19,14 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
         elif "DB_RIDT" in os.environ:
             password = os.environ["RIDT_PASSWORD"]
             req = requests.get(
-                "https://database-test-ridt.util.repl.co", auth=("test", password)
+                "https://database-test-ridt-util.replit.app", auth=("test", password)
             )
             url = req.text
             self.db = AsyncDatabase(url)
         else:
             password = os.environ["PASSWORD"]
             req = requests.get(
-                "https://database-test-jwt.util.repl.co", auth=("test", password)
+                "https://database-test-jwt-util.replit.app", auth=("test", password)
             )
             url = req.text
             self.db = AsyncDatabase(url)
@@ -136,7 +136,7 @@ class TestDatabase(unittest.TestCase):
         else:
             password = os.environ["PASSWORD"]
             req = requests.get(
-                "https://database-test-jwt.kochman.repl.co", auth=("test", password)
+                "https://database-test-jwt-py-util.replit.app", auth=("test", password)
             )
             url = req.text
             self.db = Database(url)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -133,6 +133,13 @@ class TestDatabase(unittest.TestCase):
         """Grab a JWT for all the tests to share."""
         if "REPLIT_DB_URL" in os.environ:
             self.db = Database(os.environ["REPLIT_DB_URL"])
+        elif "DB_RIDT" in os.environ:
+            password = os.environ["RIDT_PASSWORD"]
+            req = requests.get(
+                "https://database-test-ridt-util.replit.app", auth=("test", password)
+            )
+            url = req.text
+            self.db = Database(url)
         else:
             password = os.environ["PASSWORD"]
             req = requests.get(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -24,7 +24,7 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
             url = req.text
             self.db = AsyncDatabase(url)
         else:
-            password = os.environ["PASSWORD"]
+            password = os.environ["JWT_PASSWORD"]
             req = requests.get(
                 "https://database-test-jwt-util.replit.app", auth=("test", password)
             )
@@ -141,7 +141,7 @@ class TestDatabase(unittest.TestCase):
             url = req.text
             self.db = Database(url)
         else:
-            password = os.environ["PASSWORD"]
+            password = os.environ["JWT_PASSWORD"]
             req = requests.get(
                 "https://database-test-jwt-util.replit.app", auth=("test", password)
             )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -136,7 +136,7 @@ class TestDatabase(unittest.TestCase):
         else:
             password = os.environ["PASSWORD"]
             req = requests.get(
-                "https://database-test-jwt-py-util.replit.app", auth=("test", password)
+                "https://database-test-jwt-util.replit.app", auth=("test", password)
             )
             url = req.text
             self.db = Database(url)


### PR DESCRIPTION
Why
===
* Flask released a 3.0.0 version, which we couldn't support because of our version bounds. The changelog
https://flask.palletsprojects.com/en/3.0.x/changes/ looks innocuous for our purposes

What changed
===
* Changed pyproject.toml to use >=2.0.0 instead of ^2.0.0
* nix run nixpkgs#poetry -- lock --no-update

Test plan
===
* try installing this verison in a repl after it is released
* nix run nixpkgs#poetry -- check --lock

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
