### PR TITLE
Remove outdated gif in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ### `>>> import replit`
 
-![compute](https://github.com/kennethreitz42/replit-py/blob/kr-cleanup/ext/readme.gif?raw=true)
-
 This repository is the home for the `replit` Python package, which provides:
 
 - A fully-featured database client for [Replit DB](https://docs.repl.it/misc/database).


### PR DESCRIPTION
Why
===

This gif is painfully old. We should remove it since it doesn't reflect the product accurately anymore.

What changed
============

Remove outdated gif in README

Test plan
=========

- Open README
- No more outdated gif
