### PR TITLE
s/repl.it/Replit in pyproject.toml and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository is the home for the `replit` Python package, which provides:
 
-- A fully-featured database client for [Replit DB](https://docs.repl.it/misc/database).
+- A fully-featured database client for [Replit DB](https://docs.replit.com/category/databases).
 - A Flask–based application framework for accelerating development on the platform.
 - Replit user profile metadata retrieval (more coming here!).
 - A simple audio library that can play tones and audio files!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "replit"
 version = "0.0.0"  # Set by GitHub Actions
-description = "A library for interacting with features of repl.it"
-authors = ["Repl.it <contact@repl.it>", "mat <pypi@matdoes.dev>", "kennethreitz <me@kennethreitz.org>", "Scoder12 <pypi@scoder12.ml>", "AllAwesome497", ]
+description = "A library for interacting with features of Replit"
+authors = ["Replit <contact@replit.com>", "mat <pypi@matdoes.dev>", "kennethreitz <me@kennethreitz.org>", "Scoder12 <pypi@scoder12.ml>", "AllAwesome497", ]
 license = "ISC"
 readme = "README.md"
 repository = "https://github.com/replit/replit-py"


### PR DESCRIPTION
Why
===

![drop-the-dot](https://github.com/replit/replit-py/assets/24947334/651f358b-6ee2-4bc7-a9d4-d75384fc758c)

What changed
============

s/repl.it/Replit in pyproject.toml and README

Test plan
=========

Should see the description changes reflected after the next publish

