### PR TITLE
chore/Sensible defaults inside Replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -5,5 +5,3 @@ modules = ["python-3.10:v25-20230920-d4ad2e4"]
 [nix]
 channel = "stable-23_11"
 
-[deployment]
-run = ["sh", "-c", "python3 main.py"]

--- a/.replit
+++ b/.replit
@@ -1,0 +1,9 @@
+run = "poetry run python -m unittest"
+modules = ["python-3.10:v25-20230920-d4ad2e4"]
+
+# Specifies which nix channel to use when building the environment.
+[nix]
+channel = "stable-23_11"
+
+[deployment]
+run = ["sh", "-c", "python3 main.py"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ### `>>> import replit`
 
+[![Run on Repl.it](https://img.shields.io/badge/run-on_Replit-f26208?logo=replit)](https://repl.it/github/replit/replit-py) [![pypi: replit](https://img.shields.io/pypi/v/replit)](https://pypi.org/project/replit/)
+
 This repository is the home for the `replit` Python package, which provides:
 
 - A fully-featured database client for [Replit DB](https://docs.replit.com/category/databases).

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -26,7 +26,8 @@ class TestIdentity(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up the public keys."""
-        if "REPL_PUBKEYS" not in os.environ:
+        pubkeys = json.loads(os.getenv("REPL_PUBKEYS", "{}"))
+        if "dev:1" not in pubkeys:
             os.environ["REPL_PUBKEYS"] = json.dumps({"dev:1": PUBLIC_KEY})
 
     def test_read_public_key_from_env(self) -> None:


### PR DESCRIPTION
Why
===

Making it easier to develop replit-py on Replit

What changed
============

- `.replit`
- Patch tests to coexist with existing environ

Test plan
=========

`Run` should run tests inside a repl

Rollout
=======

- [x] This is fully backward and forward compatible
