### PR TITLE
Fix typo (#141)

### DIFF
--- a/src/replit/audio/__init__.py
+++ b/src/replit/audio/__init__.py
@@ -133,7 +133,7 @@ class Source:
     @property
     def duration(self) -> timedelta:
         """The duration of the source."""
-        return timedelta(millaseconds=self.__payload["Duration"])
+        return timedelta(milliseconds=self.__payload["Duration"])
 
     def get_volume(self) -> float:
         """The volume the source is set to."""


### PR DESCRIPTION
All I did was fix a typo in `audio/__init__.py` that appeared to have been "fixed" around 2020 but actually wasn't.