### PR TITLE
[docs][security] fix zipp security report

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -9,3 +9,4 @@ urllib3>=2.2.2,<3
 aiohttp-retry>=2.8.3
 sphinx-autodoc-typehints>=3.1.0
 sphinx_click>=6.0.0
+zipp>=3.19.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -74,7 +74,7 @@ multidict==6.1.0
     #   yarl
 packaging==24.2
     # via sphinx
-propcache==0.2.1
+propcache==0.3.0
     # via
     #   aiohttp
     #   yarl
@@ -128,3 +128,5 @@ werkzeug==3.1.3
     #   flask
 yarl==1.18.3
     # via aiohttp
+zipp==3.21.0
+    # via -r requirements.in


### PR DESCRIPTION
Why
===
* The zipp dependency used in the docs has a security report
* Let's fix it.

What changed
===
* Add zipp to requirements.in (bumping it from an indirect dependency to direct so we can control the version)
* run pip-compile

Test plan
===
* CI still builds the docs

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
