### PR TITLE
[ci] update ubuntu image

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: replit-py
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404
 blocks:
   - name: Lint and test
     task:


### PR DESCRIPTION
Why
===
* Semaphore removed ubuntu 2004 image

What changed
===
* Switch to 2404

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [ ] This is fully backward and forward compatible
